### PR TITLE
[FCE-274] Remove enums from SDK

### DIFF
--- a/examples/video-chat/hooks/useJoinRoom.ts
+++ b/examples/video-chat/hooks/useJoinRoom.ts
@@ -1,8 +1,4 @@
-import {
-  useCamera,
-  useMicrophone,
-  VideoQuality,
-} from '@fishjam-cloud/react-native-client';
+import { useCamera, useMicrophone } from '@fishjam-cloud/react-native-client';
 import notifee, {
   AndroidImportance,
   AndroidColor,

--- a/examples/video-chat/hooks/useJoinRoom.ts
+++ b/examples/video-chat/hooks/useJoinRoom.ts
@@ -57,7 +57,7 @@ export function useJoinRoom({
         activeEncodings:
           Platform.OS === 'android' ? ['l', 'm', 'h'] : ['l', 'h'],
       },
-      quality: VideoQuality.HD_169,
+      quality: 'HD169',
       maxBandwidth: { l: 150, m: 500, h: 1500 },
       videoTrackMetadata: { active: isCameraAvailable, type: 'camera' },
       captureDeviceId: await getCaptureDevices().then(

--- a/examples/video-chat/screens/RoomScreen.tsx
+++ b/examples/video-chat/screens/RoomScreen.tsx
@@ -81,7 +81,7 @@ const RoomScreen = ({ navigation, route }: Props) => {
         type: 'screensharing',
         active: !isScreencastOn,
       },
-      quality: ScreencastQuality.HD15,
+      quality: 'HD15',
     });
   }, [isScreencastOn, toggleScreencast]);
 

--- a/examples/video-chat/screens/RoomScreen.tsx
+++ b/examples/video-chat/screens/RoomScreen.tsx
@@ -2,7 +2,6 @@ import {
   leaveRoom,
   usePeers,
   useScreencast,
-  ScreencastQuality,
   useCamera,
   useMicrophone,
   useAudioSettings,

--- a/examples/video-chat/scripts/lint.sh
+++ b/examples/video-chat/scripts/lint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "Running eslint for react-native javascript files \n"
-eslint . --ext .ts,.tsx --fix
+echo "Running eslint for video-chat javascript files \n"
+eslint . --ext .ts,.tsx --fix --max-warnings 0
 
-echo "Running prettier for react-native javascript files \n"
+echo "Running prettier for video-chat javascript files \n"
 prettier --write . --ignore-path ./.eslintignore

--- a/examples/video-chat/scripts/lint_check.sh
+++ b/examples/video-chat/scripts/lint_check.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Running eslint:check for react-native javascript files \n"
-eslint . --ext .ts,.tsx
+eslint . --ext .ts,.tsx --max-warnings 0
 
 echo "Running prettier:check for react-native javascript files \n"
 prettier --check . --ignore-path ./.eslintignore

--- a/examples/webdriverio-test/scripts/lint.sh
+++ b/examples/webdriverio-test/scripts/lint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "Running eslint for react-native javascript files \n"
-eslint . --ext .ts,.tsx --fix
+echo "Running eslint for webdriverio-test javascript files \n"
+eslint . --ext .ts,.tsx --fix --max-warnings 0
 
-echo "Running prettier for react-native javascript files \n"
+echo "Running prettier for webdriverio-test javascript files \n"
 prettier --write . --ignore-path ./.eslintignore

--- a/examples/webdriverio-test/scripts/lint_check.sh
+++ b/examples/webdriverio-test/scripts/lint_check.sh
@@ -1,5 +1,5 @@
 echo "Running eslint:check for react-native javascript files \n"
-eslint . --ext .ts,.tsx
+eslint . --ext .ts,.tsx --max-warnings 0
 
 echo "Running prettier:check for react-native javascript files \n"
 prettier --check . --ignore-path ./.eslintignore

--- a/packages/react-native-client/scripts/lint.sh
+++ b/packages/react-native-client/scripts/lint.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "Running eslint for react-native javascript files \n"
-eslint . --ext .ts,.tsx --fix
+eslint . --ext .ts,.tsx --fix --max-warnings 0
 
 echo "Running prettier for react-native javascript files \n"
 prettier --write . --ignore-path ./.eslintignore

--- a/packages/react-native-client/scripts/lint_check.sh
+++ b/packages/react-native-client/scripts/lint_check.sh
@@ -1,5 +1,5 @@
 echo "Running eslint:check for react-native javascript files \n"
-eslint . --ext .ts,.tsx
+eslint . --ext .ts,.tsx  --max-warnings 0
 
 echo "Running prettier:check for react-native javascript files \n"
 prettier --check . --ignore-path ./.eslintignore

--- a/packages/react-native-client/src/common/webRTC.ts
+++ b/packages/react-native-client/src/common/webRTC.ts
@@ -1,13 +1,7 @@
 import { TrackEncoding } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 
-export enum LoggingSeverity {
-  Verbose = 'verbose',
-  Info = 'info',
-  Warning = 'warning',
-  Error = 'error',
-  None = 'none',
-}
+export type LoggingSeverity = 'verbose' | 'info' | 'warning' | 'error' | 'none';
 
 /**
  * sets track encoding that server should send to the client library.

--- a/packages/react-native-client/src/hooks/useAudioSettings.ts
+++ b/packages/react-native-client/src/hooks/useAudioSettings.ts
@@ -4,17 +4,13 @@ import { Platform } from 'react-native';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 import { ReceivableEvents, eventEmitter } from '../common/eventEmitter';
 
-export enum AudioOutputDeviceType {
-  Bluetooth = 'bluetooth',
-  Headset = 'headset',
-  Speaker = 'speaker',
-  Earpiece = 'earpiece',
-}
+export type AudioOutputDeviceType =
+  | 'bluetooth'
+  | 'headset'
+  | 'speaker'
+  | 'earpiece';
 
-export enum AudioSessionMode {
-  VoiceChat = 'voiceChat',
-  VideoChat = 'videoChat',
-}
+export type AudioSessionMode = 'voiceChat' | 'videoChat';
 
 export type AudioOutputDevice = {
   type: AudioOutputDeviceType;

--- a/packages/react-native-client/src/hooks/useCamera.ts
+++ b/packages/react-native-client/src/hooks/useCamera.ts
@@ -21,18 +21,17 @@ export type CaptureDevice = {
   isBackFacing: boolean;
 };
 
-export enum VideoQuality {
-  QVGA_169 = 'QVGA169',
-  VGA_169 = 'VGA169',
-  QHD_169 = 'QHD169',
-  HD_169 = 'HD169',
-  FHD_169 = 'FHD169',
-  QVGA_43 = 'QVGA43',
-  VGA_43 = 'VGA43',
-  QHD_43 = 'QHD43',
-  HD_43 = 'HD43',
-  FHD_43 = 'FHD43',
-}
+export type VideoQuality =
+  | 'QVGA169'
+  | 'VGA169'
+  | 'QHD169'
+  | 'HD169'
+  | 'FHD169'
+  | 'QVGA43'
+  | 'VGA43'
+  | 'QHD43'
+  | 'HD43'
+  | 'FHD43';
 
 export type CameraConfig<MetadataType extends Metadata> = {
   /**

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -9,8 +9,8 @@ export type TrackType = 'Audio' | 'Video';
 /**
  * Type describing Voice Activity Detection statuses.
  *
- * SPEECH - voice activity has been detected
- * SILENCE - lack of voice activity has been detected
+ * speech - voice activity has been detected
+ * silence - lack of voice activity has been detected
  */
 export type VadStatus = 'silence' | 'speech';
 
@@ -30,11 +30,11 @@ export type Track<MetadataType extends Metadata> = {
 /**
  * Type describing possible reasons of currently selected encoding.
  *
- * - OTHER - the exact reason couldn't be determined
- * - ENCODING_INACTIVE - previously selected encoding became inactive
- * - LOW_BANDWIDTH - there is no longer enough bandwidth to maintain previously selected encoding
+ * - other - the exact reason couldn't be determined
+ * - encoding_inactive - previously selected encoding became inactive
+ * - low_bandwidth - there is no longer enough bandwidth to maintain previously selected encoding
  */
-export type EncodingReason = 'other' | 'encodingInactive' | 'lowBandwidth';
+export type EncodingReason = 'other' | 'encoding_inactive' | 'low_bandwidth';
 
 export type EndpointsUpdateEvent<
   MetadataType extends Metadata,

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -4,10 +4,7 @@ import { Metadata, SimulcastConfig, TrackEncoding } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 import { ReceivableEvents, eventEmitter } from '../common/eventEmitter';
 
-export enum TrackType {
-  Audio = 'Audio',
-  Video = 'Video',
-}
+export type TrackType = 'Audio' | 'Video';
 
 /**
  * Type describing Voice Activity Detection statuses.
@@ -15,10 +12,7 @@ export enum TrackType {
  * SPEECH - voice activity has been detected
  * SILENCE - lack of voice activity has been detected
  */
-export enum VadStatus {
-  Silence = 'silence',
-  Speech = 'speech',
-}
+export type VadStatus = 'silence' | 'speech';
 
 export type Track<MetadataType extends Metadata> = {
   id: string;
@@ -40,11 +34,7 @@ export type Track<MetadataType extends Metadata> = {
  * - ENCODING_INACTIVE - previously selected encoding became inactive
  * - LOW_BANDWIDTH - there is no longer enough bandwidth to maintain previously selected encoding
  */
-export enum EncodingReason {
-  Other = 'other',
-  EncodingInactive = 'encodingInactive',
-  LowBandwidth = 'lowBandwidth',
-}
+export type EncodingReason = 'other' | 'encodingInactive' | 'lowBandwidth';
 
 export type EndpointsUpdateEvent<
   MetadataType extends Metadata,

--- a/packages/react-native-client/src/hooks/useScreencast.ts
+++ b/packages/react-native-client/src/hooks/useScreencast.ts
@@ -12,13 +12,7 @@ import { ReceivableEvents, eventEmitter } from '../common/eventEmitter';
 
 type IsScreencastOnEvent = { IsScreencastOn: boolean };
 
-export enum ScreencastQuality {
-  VGA = 'VGA',
-  HD5 = 'HD5',
-  HD15 = 'HD15',
-  FHD15 = 'FHD15',
-  FHD30 = 'FHD30',
-}
+export type ScreencastQuality = 'VGA' | 'HD5' | 'HD15' | 'FHD15' | 'FHD30';
 
 export type ScreencastOptions<MetadataType extends Metadata> = {
   /**

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -36,10 +36,10 @@ export {
   updateVideoTrackMetadata,
 } from './common/metadata';
 
+export type { LoggingSeverity } from './common/webRTC';
 export {
   changeWebRTCLoggingSeverity,
   setTargetTrackEncoding,
-  LoggingSeverity,
 } from './common/webRTC';
 
 export { connect, leaveRoom } from './common/client';

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -27,8 +27,11 @@ export { useMicrophone } from './hooks/useMicrophone';
 
 export { useRTCStatistics } from './stats/useRTCStatistics';
 
-export type { ScreencastOptions } from './hooks/useScreencast';
-export { useScreencast, ScreencastQuality } from './hooks/useScreencast';
+export type {
+  ScreencastOptions,
+  ScreencastQuality,
+} from './hooks/useScreencast';
+export { useScreencast } from './hooks/useScreencast';
 
 export {
   updateAudioTrackMetadata,

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -6,12 +6,12 @@ export {
   EncodingReason,
 } from './hooks/usePeers';
 
-export type { AudioOutputDevice } from './hooks/useAudioSettings';
-export {
-  useAudioSettings,
+export type {
+  AudioOutputDevice,
   AudioOutputDeviceType,
   AudioSessionMode,
 } from './hooks/useAudioSettings';
+export { useAudioSettings } from './hooks/useAudioSettings';
 
 export type { BandwidthEstimationEvent } from './hooks/useBandwidthEstimation';
 export { useBandwidthEstimation } from './hooks/useBandwidthEstimation';

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -16,8 +16,12 @@ export {
 export type { BandwidthEstimationEvent } from './hooks/useBandwidthEstimation';
 export { useBandwidthEstimation } from './hooks/useBandwidthEstimation';
 
-export type { CaptureDevice, CameraConfig } from './hooks/useCamera';
-export { useCamera, VideoQuality } from './hooks/useCamera';
+export type {
+  CaptureDevice,
+  CameraConfig,
+  VideoQuality,
+} from './hooks/useCamera';
+export { useCamera } from './hooks/useCamera';
 
 export type {
   IsMicrophoneOnEvent,

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -1,10 +1,11 @@
-export type { Peer, Track } from './hooks/usePeers';
-export {
-  usePeers,
+export type {
+  Peer,
+  Track,
   TrackType,
   VadStatus,
   EncodingReason,
 } from './hooks/usePeers';
+export { usePeers } from './hooks/usePeers';
 
 export type {
   AudioOutputDevice,
@@ -64,5 +65,5 @@ export type {
   SimulcastBandwidthLimit,
   BandwidthLimit,
   SimulcastConfig,
+  VideoLayout,
 } from './types';
-export { VideoLayout } from './types';

--- a/packages/react-native-client/src/types.ts
+++ b/packages/react-native-client/src/types.ts
@@ -1,10 +1,7 @@
 // global
 export type Metadata = { [key: string]: any };
 
-export enum VideoLayout {
-  FILL = 'FILL',
-  FIT = 'FIT',
-}
+export type VideoLayout = 'FILL' | 'FIT';
 
 export type TrackEncoding = 'l' | 'm' | 'h';
 


### PR DESCRIPTION
## Description

Remove `enum`s from TypeScript code. And use `union`s instead. 

Fix bug, where `EncodingReason` had incorrect mapping to native part.

## Motivation and Context

Enums bad. Unions good.
