### PR TITLE
update release workflow

### DIFF
--- a/.github/workflows/all_packages_release.yaml
+++ b/.github/workflows/all_packages_release.yaml
@@ -2,76 +2,54 @@ name: Release all mobile packages
 
 on:
   push:
-    branches:
-      - main
     tags:
-      - '*'
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   release-mobile-packages:
     runs-on: macOS-latest
-
+    permissions:
+      contents: write
+    env:
+      TAG_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check if tagged push to main
-        id: check_tag
-        run: |
-          echo "::set-output name=tagged_push::false"
-          if [[ "${{ github.ref }}" == "refs/heads/main" && ! -z "${{ github.event.push.tags }}" ]]; then
-            echo "::set-output name=tagged_push::true"
-            echo "Branch is main and tag is present"
-          else
-            echo "Branch is not main or tag did not trigger workflow"
-          fi
-
-      - name: Get the tag name
-        if: steps.check_tag.outputs.tagged_push == 'true'
-        id: tag_name
-        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}"
-
       - name: Git configuration
-        if: steps.check_tag.outputs.tagged_push == 'true'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
 
       - name: Run CocoaPod publish check
-        if: steps.check_tag.outputs.tagged_push == 'true'
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod lib lint FishjamCloudClient.podspec
 
       - name: Run npm publish check
-        if: steps.check_tag.outputs.tagged_push == 'true'
-        run: npm publish --dry-run --verbose --access public --tag ${{ steps.tag_name.outputs.TAG_NAME }}
+        run: npm publish --dry-run --verbose --access public --tag ${{ env.TAG_NAME }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/react-native-client
 
       - name: Publish to CocoaPod
-        if: steps.check_tag.outputs.tagged_push == 'true'
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod trunk push FishjamCloudClient.podspec
 
       - name: Publish to npm
-        if: steps.check_tag.outputs.tagged_push == 'true'
-        run: npm publish --verbose --access public --tag ${{ steps.tag_name.outputs.TAG_NAME }}
+        run: npm publish --verbose --access public --tag ${{ env.TAG_NAME }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/react-native-client
 
-
       - name: Create GitHub release
-        if: steps.check_tag.outputs.tagged_push == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          name: 'Release ${{ steps.tag_name.outputs.TAG_NAME }}'
-          tag_name: ${{ steps.tag_name.outputs.TAG_NAME }}
+          name: 'Release ${{ env.TAG_NAME }}'
+          tag_name: ${{ env.TAG_NAME }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/all_packages_release.yaml
+++ b/.github/workflows/all_packages_release.yaml
@@ -16,8 +16,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check if tagged push to main
+        id: check_tag
         run: |
+          echo "::set-output name=tagged_push::false"
           if [[ "${{ github.ref }}" == "refs/heads/main" && ! -z "${{ github.event.push.tags }}" ]]; then
+            echo "::set-output name=tagged_push::true"
             echo "Branch is main and tag is present"
           else
             echo "Branch is not main or tag did not trigger workflow"
@@ -25,33 +28,39 @@ jobs:
           fi
 
       - name: Get the tag name
+        if: steps.check_tag.outputs.tagged_push == 'true'
         id: tag_name
         run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}"
 
       - name: Git configuration
+        if: steps.check_tag.outputs.tagged_push == 'true'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
 
       - name: Run CocoaPod publish check
+        if: steps.check_tag.outputs.tagged_push == 'true'
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod lib lint FishjamCloudClient.podspec
 
       - name: Run npm publish check
+        if: steps.check_tag.outputs.tagged_push == 'true'
         run: npm publish --dry-run --verbose --access public --tag ${{ steps.tag_name.outputs.TAG_NAME }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/react-native-client
 
       - name: Publish to CocoaPod
+        if: steps.check_tag.outputs.tagged_push == 'true'
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod trunk push FishjamCloudClient.podspec
 
       - name: Publish to npm
+        if: steps.check_tag.outputs.tagged_push == 'true'
         run: npm publish --verbose --access public --tag ${{ steps.tag_name.outputs.TAG_NAME }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -59,6 +68,7 @@ jobs:
 
 
       - name: Create GitHub release
+        if: steps.check_tag.outputs.tagged_push == 'true'
         uses: softprops/action-gh-release@v2
         with:
           name: 'Release ${{ steps.tag_name.outputs.TAG_NAME }}'

--- a/.github/workflows/all_packages_release.yaml
+++ b/.github/workflows/all_packages_release.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macOS-latest
     permissions:
       contents: write
+      id-token: write
+
     env:
       TAG_NAME: ${{ github.ref_name }}
     steps:
@@ -21,14 +23,26 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "GitHub Actions"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Run CocoaPod publish check
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod lib lint FishjamCloudClient.podspec
 
+      - name: Run CocoaPod publish check
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod spec lint FishjamCloudClient.podspec
+
+
       - name: Run npm publish check
-        run: npm publish --dry-run --verbose --access public --tag ${{ env.TAG_NAME }}
+        run: npm publish --dry-run --verbose --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/react-native-client
@@ -40,7 +54,7 @@ jobs:
           pod trunk push FishjamCloudClient.podspec
 
       - name: Publish to npm
-        run: npm publish --verbose --access public --tag ${{ env.TAG_NAME }}
+        run: npm publish --verbose --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/react-native-client

--- a/.github/workflows/all_packages_release.yaml
+++ b/.github/workflows/all_packages_release.yaml
@@ -24,7 +24,6 @@ jobs:
             echo "Branch is main and tag is present"
           else
             echo "Branch is not main or tag did not trigger workflow"
-            exit 1
           fi
 
       - name: Get the tag name

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,6 @@
 - update version to x.y.z in [build.gradle](./packages/react-native-client/android/build.gradle)
 - update `implementation 'com.github.fishjam-cloud:mobile-client-sdk:a.b.c'` to x.y.z in [build.gradle](./packages/react-native-client/android/build.gradle)
 - commit
-- create merge request and ( after checks etc) merge it
+- create pull request and ( after checks etc) merge it
 - create tag x.y.z and push to origin
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 - update version to x.y.z in [package.json](./packages/react-native-client/package.json)
 - update version to x.y.z in [package.json](./package.json)
 - update version to x.y.z in [build.gradle](./packages/react-native-client/android/build.gradle)
+- update `implementation 'com.github.fishjam-cloud:mobile-client-sdk:a.b.c'` to x.y.z in [build.gradle](./packages/react-native-client/android/build.gradle)
 - commit
 - create merge request and ( after checks etc) merge it
 - create tag x.y.z and push to origin

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,6 @@
 - update version to x.y.z in [package.json](./package.json)
 - update version to x.y.z in [build.gradle](./packages/react-native-client/android/build.gradle)
 - commit
-- create and push tag x.y.z
-- create merge request
+- create merge request and ( after checks etc) merge it
+- create tag x.y.z and push to origin
 


### PR DESCRIPTION
Changes:
Now every tag which regex is type of: [0-9]+.[0-9]+.[0-9]+ will trigger release workflow
removed deprecated step variable
add permission to write, so it can create release on github
Example of working sollution can be found here:

[repo](https://github.com/karkakol/temp)
[npm](https://www.npmjs.com/package/@karolkakol/my-ts-lib)
[cocoapods](https://github.com/CocoaPods/Specs/commit/fed7551db348c1a66477c7ea35e33c26dbebd200)
