### PR TITLE
[FCE-312] Handle auth errors

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/Command.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/Command.kt
@@ -1,15 +1,12 @@
 package com.fishjamcloud.client
 
-import kotlinx.coroutines.CompletableJob
-import kotlinx.coroutines.Job
+import kotlin.coroutines.Continuation
 
 internal enum class CommandName {
   CONNECT,
   JOIN,
   ADD_TRACK,
-  REMOVE_TRACK,
-  RENEGOTIATE,
-  LEAVE
+  REMOVE_TRACK
 }
 
 internal enum class ClientState {
@@ -25,5 +22,7 @@ internal data class Command(
 ) {
   constructor(commandName: CommandName, command: () -> Unit = {}) : this(commandName, null, command)
 
-  val job: CompletableJob = Job()
+  var continuation: Continuation<Unit>? = null
+
+  fun isConnectionCommand(): Boolean = commandName == CommandName.CONNECT || commandName == CommandName.JOIN
 }

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/CommandsQueue.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/CommandsQueue.kt
@@ -1,28 +1,31 @@
 package com.fishjamcloud.client
 
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 internal class CommandsQueue {
   private var commandsQueue: ArrayDeque<Command> = ArrayDeque()
   var clientState: ClientState = ClientState.CREATED
 
-  fun addCommand(command: Command): Job {
+  suspend fun executeCommand(command: Command) {
     commandsQueue.add(command)
-    if (commandsQueue.size == 1) {
-      command.execute()
+    suspendCoroutine { cont ->
+      run {
+        command.continuation = cont
+        if (commandsQueue.size == 1) {
+          command.execute()
+        }
+      }
     }
-    return command.job
   }
 
   fun finishCommand() {
     val command = commandsQueue.first()
-    val job = command.job
     commandsQueue.removeFirst()
     if (command.clientStateAfterCommand != null) {
       clientState = command.clientStateAfterCommand
     }
-    job.complete()
+    command.continuation?.resume(Unit)
     // TODO: make it iterative, not recursive?
     if (commandsQueue.isNotEmpty()) {
       commandsQueue.first().execute()
@@ -41,9 +44,20 @@ internal class CommandsQueue {
     }
   }
 
-  fun clear(cause: String) {
+  fun onDisconnected() {
     clientState = ClientState.CREATED
-    commandsQueue.forEach { command -> command.job.cancel(CancellationException(cause)) }
+    commandsQueue
+      .filter { it.isConnectionCommand() }
+      .forEach { command -> command.continuation?.resume(Unit) }
+    commandsQueue.removeAll { it.isConnectionCommand() }
+    if (commandsQueue.isNotEmpty()) {
+      commandsQueue.first().execute()
+    }
+  }
+
+  fun clear() {
+    clientState = ClientState.CREATED
+    commandsQueue.forEach { command -> command.continuation?.resume(Unit) }
     commandsQueue.clear()
   }
 }

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/CommandsQueue.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/CommandsQueue.kt
@@ -7,7 +7,7 @@ internal class CommandsQueue {
   private var commandsQueue: ArrayDeque<Command> = ArrayDeque()
   var clientState: ClientState = ClientState.CREATED
 
-  suspend fun executeCommand(command: Command) {
+  suspend fun addCommand(command: Command) {
     commandsQueue.add(command)
     suspendCoroutine { cont ->
       run {

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -10,6 +10,7 @@ import com.fishjamcloud.client.media.LocalVideoTrack
 import com.fishjamcloud.client.media.RemoteAudioTrack
 import com.fishjamcloud.client.media.RemoteVideoTrack
 import com.fishjamcloud.client.media.Track
+import com.fishjamcloud.client.models.AuthError
 import com.fishjamcloud.client.models.EncodingReason
 import com.fishjamcloud.client.models.Endpoint
 import com.fishjamcloud.client.models.EndpointType
@@ -100,6 +101,18 @@ internal class FishjamClientInternal(
         ) {
           listener.onSocketClose(code, reason)
           commandsQueue.clear("Websocket was closed")
+        }
+
+        override fun onClosing(
+          webSocket: WebSocket,
+          code: Int,
+          reason: String
+        ) {
+          if (AuthError.isAuthError(reason)) {
+            listener.onAuthError(AuthError.fromString(reason))
+          }
+          commandsQueue.clear("Websocket was closed, reason: $reason")
+          webSocket.close(code, reason)
         }
 
         override fun onMessage(

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -160,7 +160,7 @@ internal class FishjamClientInternal(
       }
 
     coroutineScope.launch {
-      commandsQueue.executeCommand(
+      commandsQueue.addCommand(
         Command(CommandName.CONNECT, ClientState.CONNECTED) {
           val request = Request.Builder().url(config.websocketUrl).build()
           val webSocket =
@@ -177,7 +177,7 @@ internal class FishjamClientInternal(
 
   fun join(peerMetadata: Metadata = emptyMap()) {
     coroutineScope.launch {
-      commandsQueue.executeCommand(
+      commandsQueue.addCommand(
         Command(CommandName.JOIN, ClientState.JOINED) {
           localEndpoint = localEndpoint.copy(metadata = peerMetadata)
           rtcEngineCommunication.connect(peerMetadata)
@@ -242,7 +242,7 @@ internal class FishjamClientInternal(
     videoTrack.start()
 
     commandsQueue
-      .executeCommand(
+      .addCommand(
         Command(CommandName.ADD_TRACK) {
           localEndpoint = localEndpoint.addOrReplaceTrack(videoTrack)
 
@@ -295,7 +295,7 @@ internal class FishjamClientInternal(
     audioTrack.start()
 
     commandsQueue
-      .executeCommand(
+      .addCommand(
         Command(CommandName.ADD_TRACK) {
           localEndpoint = localEndpoint.addOrReplaceTrack(audioTrack)
 
@@ -338,7 +338,7 @@ internal class FishjamClientInternal(
     }
 
     commandsQueue
-      .executeCommand(
+      .addCommand(
         Command(CommandName.ADD_TRACK) {
           localEndpoint = localEndpoint.addOrReplaceTrack(screencastTrack)
 
@@ -354,7 +354,7 @@ internal class FishjamClientInternal(
 
   suspend fun removeTrack(trackId: String) {
     commandsQueue
-      .executeCommand(
+      .addCommand(
         Command(CommandName.REMOVE_TRACK) {
           val track: Track =
             getTrack(trackId) ?: run {

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
@@ -3,7 +3,6 @@ package com.fishjamcloud.client
 import com.fishjamcloud.client.media.Track
 import com.fishjamcloud.client.models.AuthError
 import com.fishjamcloud.client.models.Peer
-import okhttp3.Response
 import timber.log.Timber
 
 interface FishjamClientListener {
@@ -20,11 +19,8 @@ interface FishjamClientListener {
   /**
    * Emitted when occurs an error in the websocket connection
    */
-  fun onSocketError(
-    t: Throwable,
-    response: Response?
-  ) {
-    Timber.w("Socket error:", t, response)
+  fun onSocketError(t: Throwable) {
+    Timber.w("Socket error:", t)
   }
 
   /**

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
@@ -1,6 +1,7 @@
 package com.fishjamcloud.client
 
 import com.fishjamcloud.client.media.Track
+import com.fishjamcloud.client.models.AuthError
 import com.fishjamcloud.client.models.Peer
 import okhttp3.Response
 import timber.log.Timber
@@ -41,7 +42,7 @@ interface FishjamClientListener {
   /**
    * Emitted when authentication fails
    */
-  fun onAuthError()
+  fun onAuthError(reason: AuthError)
 
   /**
    * Emitted when local user is connected to fishjam.

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/AuthError.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/AuthError.kt
@@ -1,0 +1,17 @@
+package com.fishjamcloud.client.models
+
+enum class AuthError(
+  val error: String
+) {
+  MISSING_TOKEN("missing token"),
+  INVALID_TOKEN("invalid token"),
+  EXPIRED_TOKEN("expired token"),
+  ROOM_NOT_FOUND("room not found"),
+  PEER_NOT_FOUND("peer not found");
+
+  companion object {
+    fun isAuthError(error: String): Boolean = values().firstOrNull { v -> v.error == error } != null
+
+    fun fromString(error: String): AuthError = values().first { v -> v.error == error }
+  }
+}

--- a/packages/android-client/FishjamClient/src/test/java/com/fishjamcloud/test/client/FishjamClientTest.kt
+++ b/packages/android-client/FishjamClient/src/test/java/com/fishjamcloud/test/client/FishjamClientTest.kt
@@ -10,6 +10,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -42,16 +45,26 @@ class FishjamClientTest {
     every { createAudioDeviceModule(any()) } returns mockk<AudioDeviceModule>(relaxed = true)
   }
 
+  @OptIn(ExperimentalCoroutinesApi::class)
   @Before
   fun initMocksAndConnect() {
-    websocketMock = WebsocketMock()
-    fishjamClientListener = mockk(relaxed = true)
-    client = FishjamClientInternal(fishjamClientListener, mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+    runTest {
+      websocketMock = WebsocketMock()
+      fishjamClientListener = mockk(relaxed = true)
+      client =
+        FishjamClientInternal(
+          fishjamClientListener,
+          mockk(relaxed = true),
+          mockk(relaxed = true),
+          mockk(relaxed = true)
+        )
 
-    client.connect(Config(websocketUrl = url, token = token))
-    websocketMock.open()
-    verify { fishjamClientListener.onSocketOpen() }
-    websocketMock.expect(authRequest)
+      client.connect(Config(websocketUrl = url, token = token))
+      verify(timeout = 1000) { anyConstructed<OkHttpClient>().newWebSocket(any(), any()) }
+      websocketMock.open()
+      verify { fishjamClientListener.onSocketOpen() }
+      websocketMock.expect(authRequest)
+    }
   }
 
   @Test
@@ -63,7 +76,7 @@ class FishjamClientTest {
   @Test
   fun callsOnSocketError() {
     websocketMock.error()
-    verify { fishjamClientListener.onSocketError(any(), any()) }
+    verify { fishjamClientListener.onSocketError(any()) }
   }
 
   @Test

--- a/packages/android-client/FishjamClient/src/test/java/com/fishjamcloud/test/client/FishjamClientTest.kt
+++ b/packages/android-client/FishjamClient/src/test/java/com/fishjamcloud/test/client/FishjamClientTest.kt
@@ -60,7 +60,7 @@ class FishjamClientTest {
         )
 
       client.connect(Config(websocketUrl = url, token = token))
-      verify(timeout = 1000) { anyConstructed<OkHttpClient>().newWebSocket(any(), any()) }
+      verify(timeout = 2000) { anyConstructed<OkHttpClient>().newWebSocket(any(), any()) }
       websocketMock.open()
       verify { fishjamClientListener.onSocketOpen() }
       websocketMock.expect(authRequest)

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -156,6 +156,9 @@ internal class FishjamClientInternal: MembraneRTCDelegate, WebSocketDelegate {
     }
 
     func onSocketClose(code: UInt16, reason: String) {
+        if let authError = AuthError(rawValue: reason) {
+            onAuthError(reason: authError)
+        }
         listener.onSocketClose(code: code, reason: reason)
     }
 
@@ -172,8 +175,8 @@ internal class FishjamClientInternal: MembraneRTCDelegate, WebSocketDelegate {
         listener.onAuthSuccess()
     }
 
-    func onAuthError() {
-        listener.onAuthError()
+    func onAuthError(reason: AuthError) {
+        listener.onAuthError(reason: reason)
     }
 
     func onDisconnected() {

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
@@ -23,7 +23,7 @@ public protocol FishjamClientListener {
     /**
      * Emitted when authentication fails
      */
-    func onAuthError()
+    func onAuthError(reason: AuthError)
 
     /**
      * Emitted when the connection is closed

--- a/packages/ios-client/Sources/MembraneRTC/Types/AuthError.swift
+++ b/packages/ios-client/Sources/MembraneRTC/Types/AuthError.swift
@@ -1,0 +1,7 @@
+public enum AuthError: String, CaseIterable {
+    case missing_token = "missing token"
+    case invalid_token = "invalid token"
+    case expired_token = "expired token"
+    case room_not_found = "room not found"
+    case peer_not_found = "peer not found"
+}

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/Errors.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/Errors.kt
@@ -1,0 +1,31 @@
+package org.membraneframework.reactnative
+
+import com.fishjamcloud.client.models.AuthError
+import expo.modules.kotlin.exception.CodedException
+
+class JoinError(
+  metadata: Any
+) : CodedException(message = "Join error: $metadata")
+
+class ConnectionError(
+  reason: AuthError
+) : CodedException(message = "Connection error: ${reason.error}")
+
+class MissingScreencastPermission : CodedException(message = "No permission to start screencast, call handleScreencastPermission first.")
+
+class ClientNotConnectedError : CodedException(message = "Client not connected to server yet. Make sure to call connect() first!")
+
+class NoLocalVideoTrackError : CodedException(message = "No local video track. Make sure to call connect() first!")
+
+class NoLocalAudioTrackError : CodedException(message = "No local audio track. Make sure to call connect() first!")
+
+class NoScreencastTrackError : CodedException(message = "No local screencast track. Make sure to toggle screencast on first!")
+
+class SocketClosedError(
+  code: Int,
+  reason: String
+) : CodedException(message = "Socket was closed with code = $code and reason = $reason")
+
+class SocketError(
+  message: String
+) : CodedException(message = "Socket error: $message")

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
@@ -14,6 +14,7 @@ import com.fishjamcloud.client.media.LocalVideoTrack
 import com.fishjamcloud.client.media.RemoteAudioTrack
 import com.fishjamcloud.client.media.RemoteVideoTrack
 import com.fishjamcloud.client.media.Track
+import com.fishjamcloud.client.models.AuthError
 import com.fishjamcloud.client.models.Endpoint
 import com.fishjamcloud.client.models.Metadata
 import com.fishjamcloud.client.models.Peer
@@ -221,9 +222,9 @@ class RNFishjamClient(
     }
   }
 
-  override fun onAuthError() {
+  override fun onAuthError(reason: AuthError) {
     CoroutineScope(Dispatchers.Main).launch {
-      connectPromise?.reject(CodedException("Connection error"))
+      connectPromise?.reject(CodedException("Connection error: ${reason.error}"))
       connectPromise = null
     }
   }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -271,9 +271,9 @@ class RNFishjamClient: FishjamClientListener {
         joinRoom()
     }
 
-    func onAuthError() {
+    func onAuthError(reason: AuthError) {
         if let connectPromise = connectPromise {
-            connectPromise.reject("E_MEMBRANE_CONNECT", "Failed to connect: socket error")
+            connectPromise.reject("E_MEMBRANE_CONNECT", "Failed to connect: \(reason.rawValue)")
         }
         connectPromise = nil
     }


### PR DESCRIPTION
This PR adds error handling of auth errors like invalid/expired token etc. 
The commands queue no longer ends jobs by throwing exceptions but ends them gracefully.
It also makes errors on RN Android nicer (all possible errors with error messages are specified in one file). 