### PR TITLE
[FCE-313] Add reconnection feature

### DIFF
--- a/examples/video-chat/App.tsx
+++ b/examples/video-chat/App.tsx
@@ -3,8 +3,11 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
 
 import AppNavigator from './navigators/AppNavigator';
+import { useReconnectionToasts } from './hooks/useReconnectionToasts';
 
 function App(): React.JSX.Element {
+  useReconnectionToasts();
+
   return (
     <>
       <GestureHandlerRootView>

--- a/examples/video-chat/hooks/useReconnectionToasts.ts
+++ b/examples/video-chat/hooks/useReconnectionToasts.ts
@@ -1,0 +1,29 @@
+import {
+  ReconnectionStatus,
+  useReconnection,
+} from '@fishjam-cloud/react-native-client';
+import { useEffect, useRef } from 'react';
+import Toast from 'react-native-toast-message';
+
+export function useReconnectionToasts() {
+  const prevStatus = useRef<ReconnectionStatus>('idle');
+  const { reconnectionStatus } = useReconnection();
+
+  useEffect(() => {
+    if (prevStatus.current == reconnectionStatus) return;
+    prevStatus.current = reconnectionStatus;
+    if (reconnectionStatus == 'error') {
+      Toast.show({
+        text1: 'Failed to reconnect',
+      });
+    } else if (reconnectionStatus == 'reconnecting') {
+      Toast.show({
+        text1: 'Connection is broken, reconnecting...',
+      });
+    } else {
+      Toast.show({
+        text1: 'Connected succesfully',
+      });
+    }
+  }, [reconnectionStatus]);
+}

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClient.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClient.kt
@@ -10,6 +10,7 @@ import com.fishjamcloud.client.models.EncoderOptions
 import com.fishjamcloud.client.models.Metadata
 import com.fishjamcloud.client.models.Peer
 import com.fishjamcloud.client.models.RTCStats
+import com.fishjamcloud.client.models.ReconnectConfig
 import com.fishjamcloud.client.models.TrackBandwidthLimit
 import com.fishjamcloud.client.models.TrackEncoding
 import com.fishjamcloud.client.models.VideoParameters
@@ -21,7 +22,9 @@ import org.webrtc.Logging
 
 data class Config(
   val websocketUrl: String,
-  val token: String
+  val token: String,
+  val peerMetadata: Metadata,
+  val reconnectConfig: ReconnectConfig
 )
 
 class FishjamClient(
@@ -50,17 +53,6 @@ class FishjamClient(
    */
   fun leave() {
     client.leave()
-  }
-
-  /**
-   * Tries to join the room. If user is accepted then {@link FishjamClient.onConnected} will be called.
-   * In other case {@link FishjamClient.onConnectError} is invoked.
-   *
-   * @param peerMetadata - Any information that other peers will receive in onPeerJoined
-   * after accepting this peer
-   */
-  fun join(peerMetadata: Metadata = emptyMap()) {
-    client.join(peerMetadata)
   }
 
   /**

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
@@ -5,7 +5,7 @@ import com.fishjamcloud.client.models.AuthError
 import com.fishjamcloud.client.models.Peer
 import timber.log.Timber
 
-interface FishjamClientListener {
+interface FishjamClientListener : ReconnectionManagerListener {
   /**
    * Emitted when the websocket connection is closed
    */

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ReconnectionManager.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ReconnectionManager.kt
@@ -1,0 +1,78 @@
+package com.fishjamcloud.client
+
+import com.fishjamcloud.client.models.ReconnectConfig
+import timber.log.Timber
+import java.util.Timer
+import kotlin.concurrent.schedule
+
+interface ReconnectionManagerListener {
+  fun onReconnectionStarted() {
+    Timber.i("Reconnection started")
+  }
+
+  fun onReconnected() {
+    Timber.i("Reconnected successfully")
+  }
+
+  fun onReconnectionRetriesLimitReached() {
+    Timber.e("Reconnection retries limit reached")
+  }
+}
+
+enum class ReconnectionStatus {
+  IDLE,
+  RECONNECTING,
+  ERROR,
+  WAITING
+}
+
+internal class ReconnectionManager(
+  private var reconnectConfig: ReconnectConfig = ReconnectConfig(),
+  private val connect: () -> Unit
+) {
+  private val listeners = mutableListOf<ReconnectionManagerListener>()
+  private var reconnectAttempts = 0
+  private var reconnectionStatus = ReconnectionStatus.IDLE
+
+  fun onDisconnected() {
+    if (reconnectAttempts >= reconnectConfig.maxAttempts) {
+      reconnectionStatus = ReconnectionStatus.ERROR
+      listeners.forEach { it.onReconnectionRetriesLimitReached() }
+      return
+    }
+
+    if (reconnectionStatus == ReconnectionStatus.WAITING) {
+      return
+    }
+
+    if (reconnectionStatus != ReconnectionStatus.RECONNECTING) {
+      reconnectionStatus = ReconnectionStatus.RECONNECTING
+      listeners.forEach { it.onReconnectionStarted() }
+    }
+    val delay = reconnectConfig.initialDelayMs + reconnectAttempts * reconnectConfig.delayMs
+    reconnectAttempts += 1
+    Timer().schedule(delay) {
+      reconnectionStatus = ReconnectionStatus.RECONNECTING
+      connect()
+    }
+  }
+
+  fun onReconnected() {
+    if (reconnectionStatus != ReconnectionStatus.RECONNECTING) return
+    reset()
+    listeners.forEach { it.onReconnected() }
+  }
+
+  fun reset() {
+    reconnectAttempts = 0
+    reconnectionStatus = ReconnectionStatus.IDLE
+  }
+
+  fun addListener(listener: ReconnectionManagerListener) {
+    listeners.add(listener)
+  }
+
+  fun removeListener(listener: ReconnectionManagerListener) {
+    listeners.remove(listener)
+  }
+}

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalAudioTrack.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalAudioTrack.kt
@@ -1,14 +1,21 @@
 package com.fishjamcloud.client.media
 
 import com.fishjamcloud.client.models.Metadata
+import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 
 class LocalAudioTrack(
   mediaTrack: AudioTrack,
   endpointId: String,
-  metadata: Metadata
+  metadata: Metadata,
+  internal val audioSource: AudioSource
 ) : Track(mediaTrack, endpointId, null, metadata),
   LocalTrack {
+  constructor(
+    mediaTrack: AudioTrack,
+    oldTrack: LocalAudioTrack
+  ) : this(mediaTrack, oldTrack.endpointId, oldTrack.metadata, oldTrack.audioSource)
+
   override fun start() {
   }
 

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalScreencastTrack.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalScreencastTrack.kt
@@ -10,16 +10,23 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.webrtc.ScreenCapturerAndroid
+import org.webrtc.VideoSource
 import java.util.ArrayList
 
 class LocalScreencastTrack(
   videoTrack: org.webrtc.VideoTrack,
   endpointId: String,
   metadata: Metadata,
-  private val capturer: ScreenCapturerAndroid,
-  val videoParameters: VideoParameters
+  internal val capturer: ScreenCapturerAndroid,
+  val videoParameters: VideoParameters,
+  internal val videoSource: VideoSource
 ) : VideoTrack(videoTrack, endpointId, null, metadata),
   LocalTrack {
+  constructor(
+    videoTrack: org.webrtc.VideoTrack,
+    oldTrack: LocalScreencastTrack
+  ) : this(videoTrack, oldTrack.endpointId, oldTrack.metadata, oldTrack.capturer, oldTrack.videoParameters, oldTrack.videoSource)
+
   private val mutex = Mutex()
   private val coroutineScope: CoroutineScope =
     ClosableCoroutineScope(SupervisorJob())

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalVideoTrack.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/media/LocalVideoTrack.kt
@@ -24,6 +24,17 @@ class LocalVideoTrack(
   val videoParameters: VideoParameters
 ) : VideoTrack(mediaTrack, endpointId, rtcEngineId = null, metadata),
   LocalTrack {
+  val videoSource: VideoSource
+    get() = (capturer as CameraCapturer).source
+
+  constructor(mediaTrack: org.webrtc.VideoTrack, oldTrack: LocalVideoTrack) : this(
+    mediaTrack,
+    oldTrack.endpointId,
+    oldTrack.metadata,
+    oldTrack.capturer,
+    oldTrack.videoParameters
+  )
+
   data class CaptureDevice(
     val deviceName: String,
     val isFrontFacing: Boolean,
@@ -72,7 +83,7 @@ interface Capturer {
 
 class CameraCapturer(
   private val context: Context,
-  private val source: VideoSource,
+  val source: VideoSource,
   private val rootEglBase: EglBase,
   private val videoParameters: VideoParameters,
   cameraName: String?

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/AuthError.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/AuthError.kt
@@ -7,7 +7,8 @@ enum class AuthError(
   INVALID_TOKEN("invalid token"),
   EXPIRED_TOKEN("expired token"),
   ROOM_NOT_FOUND("room not found"),
-  PEER_NOT_FOUND("peer not found");
+  PEER_NOT_FOUND("peer not found"),
+  PEER_CONNECTED("peer already connected");
 
   companion object {
     fun isAuthError(error: String): Boolean = values().firstOrNull { v -> v.error == error } != null

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/ReconnectConfig.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/ReconnectConfig.kt
@@ -1,0 +1,7 @@
+package com.fishjamcloud.client.models
+
+data class ReconnectConfig(
+  val maxAttempts: Int = 5,
+  val initialDelayMs: Long = 1000,
+  val delayMs: Long = 1000
+)

--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -4,10 +4,14 @@ import WebRTC
 public struct Config {
     var websocketUrl: String
     var token: String
+    var peerMetadata: Metadata
+    var reconnectConfig: ReconnectConfig
 
-    public init(websocketUrl: String, token: String) {
+    public init(websocketUrl: String, token: String, peerMetadata: Metadata, reconnectConfig: ReconnectConfig) {
         self.websocketUrl = websocketUrl
         self.token = token
+        self.peerMetadata = peerMetadata
+        self.reconnectConfig = reconnectConfig
     }
 }
 
@@ -82,17 +86,6 @@ public class FishjamClient {
     */
     public func cleanUp() {
         client.cleanUp()
-    }
-
-    /**
-    * Tries to join the room. If user is accepted then {@link FishjamClient.onJoinSuccess} will be called.
-    * In other case {@link FishjamClient.onJoinError} is invoked.
-    *
-    * @param peerMetadata - Any information that other peers will receive in onPeerJoined
-    * after accepting this peer
-    */
-    public func join(peerMetadata: Metadata) {
-        webrtcClient.connect(metadata: peerMetadata)
     }
 
     /**

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol FishjamClientListener {
+public protocol FishjamClientListener: ReconnectionManagerListener {
     /**
      * Emitted when the websocket connection is closed
      */

--- a/packages/ios-client/Sources/FishjamClient/ReconnectionManager.swift
+++ b/packages/ios-client/Sources/FishjamClient/ReconnectionManager.swift
@@ -1,0 +1,79 @@
+enum ReconnectionStatus {
+    case IDLE
+    case RECONNECTING
+    case WAITING
+    case ERROR
+}
+
+public struct ReconnectConfig {
+    let maxAttempts: Int
+    let initialDelayMs: Int
+    let delayMs: Int
+
+    public init(maxAttempts: Int = 5, initialDelayMs: Int = 1000, delayMs: Int = 1000) {
+        self.maxAttempts = maxAttempts
+        self.initialDelayMs = initialDelayMs
+        self.delayMs = delayMs
+    }
+}
+
+public protocol ReconnectionManagerListener {
+    func onReconnectionStarted()
+    func onReconnected()
+    func onReconnectionRetriesLimitReached()
+}
+
+class ReconnectionManager {
+    private let reconnectConfig: ReconnectConfig
+    private var reconnectAttempts = 0
+    var reconnectionStatus = ReconnectionStatus.IDLE
+    private let connect: () -> Void
+    private var listener: ReconnectionManagerListener
+
+    init(reconnectConfig: ReconnectConfig, connect: @escaping () -> Void, listener: ReconnectionManagerListener) {
+        self.reconnectConfig = reconnectConfig
+        self.connect = connect
+        self.listener = listener
+    }
+
+    func onDisconnected() {
+        if reconnectAttempts >= reconnectConfig.maxAttempts {
+            reconnectionStatus = .ERROR
+            listener.onReconnectionRetriesLimitReached()
+            return
+        }
+
+        if reconnectionStatus == .WAITING {
+            return
+        }
+
+        if reconnectionStatus != .RECONNECTING {
+            reconnectionStatus = .RECONNECTING
+            listener.onReconnectionStarted()
+        }
+        let delay = (reconnectConfig.initialDelayMs + reconnectAttempts * reconnectConfig.delayMs)
+        reconnectAttempts += 1
+
+        reconnectionStatus = .WAITING
+
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + DispatchTimeInterval.milliseconds(delay),
+            execute: {
+                self.reconnectionStatus = .RECONNECTING
+                self.connect()
+            })
+    }
+
+    func onReconnected() {
+        if reconnectionStatus != .RECONNECTING {
+            return
+        }
+        reset()
+        listener.onReconnected()
+    }
+
+    func reset() {
+        reconnectAttempts = 0
+        reconnectionStatus = .IDLE
+    }
+}

--- a/packages/ios-client/Sources/FishjamClient/TestUtils.swift
+++ b/packages/ios-client/Sources/FishjamClient/TestUtils.swift
@@ -3,7 +3,10 @@ import WebRTC
 
 internal protocol FishjamMembraneRTC {
     func disconnect()
+    func connect(metadata: Metadata)
     func receiveMediaEvent(mediaEvent: SerializedMediaEvent)
+    func onDisconnected()
+    func reconnect()
 }
 
 extension MembraneRTC: FishjamMembraneRTC {}

--- a/packages/ios-client/Sources/MembraneRTC/Media/Tracks/LocalAudioTrack.swift
+++ b/packages/ios-client/Sources/MembraneRTC/Media/Tracks/LocalAudioTrack.swift
@@ -3,8 +3,8 @@ import WebRTC
 /// Utility wrapper around a local `RTCAudioTrack` managing a local audio session.
 public class LocalAudioTrack: AudioTrack, LocalTrack {
     public let track: RTCAudioTrack
-
     private let config: RTCAudioSessionConfiguration
+    private let audioSource: RTCAudioSource
 
     internal init(peerConnectionFactoryWrapper: PeerConnectionFactoryWrapper) {
         let constraints: [String: String] = [
@@ -23,8 +23,17 @@ public class LocalAudioTrack: AudioTrack, LocalTrack {
         config.mode = AVAudioSession.Mode.videoChat.rawValue
         config.categoryOptions = [.duckOthers, .allowAirPlay, .allowBluetooth, .allowBluetoothA2DP]
 
-        let audioSource = peerConnectionFactoryWrapper.createAudioSource(audioConstraints)
+        audioSource = peerConnectionFactoryWrapper.createAudioSource(audioConstraints)
 
+        let track = peerConnectionFactoryWrapper.createAudioTrack(source: audioSource)
+        track.isEnabled = true
+
+        self.track = track
+    }
+
+    internal init(oldTrack: LocalAudioTrack, peerConnectionFactoryWrapper: PeerConnectionFactoryWrapper) {
+        self.config = oldTrack.config
+        self.audioSource = oldTrack.audioSource
         let track = peerConnectionFactoryWrapper.createAudioTrack(source: audioSource)
         track.isEnabled = true
 

--- a/packages/ios-client/Sources/MembraneRTC/Media/Tracks/LocalVideoTrack.swift
+++ b/packages/ios-client/Sources/MembraneRTC/Media/Tracks/LocalVideoTrack.swift
@@ -11,6 +11,17 @@ public class LocalVideoTrack: VideoTrack, LocalTrack {
         case camera, file
     }
 
+    internal init(
+        oldTrack: LocalVideoTrack,
+        peerConnectionFactoryWrapper: PeerConnectionFactoryWrapper
+    ) {
+        self.videoSource = oldTrack.videoSource
+        self.capturer = oldTrack.capturer
+        self.videoParameters = oldTrack.videoParameters
+        track = peerConnectionFactoryWrapper.createVideoTrack(source: videoSource)
+        super.init()
+    }
+
     internal init(parameters: VideoParameters, peerConnectionFactoryWrapper: PeerConnectionFactoryWrapper) {
         let source = peerConnectionFactoryWrapper.createVideoSource()
 

--- a/packages/ios-client/Sources/MembraneRTC/MembraneRTC.swift
+++ b/packages/ios-client/Sources/MembraneRTC/MembraneRTC.swift
@@ -58,6 +58,8 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
 
     private var localTracks: [LocalTrack] = []
 
+    private var prevLocalTracks: [LocalTrack] = []
+
     private var localEndpoint = Endpoint(id: "", type: "webrtc", metadata: .init([:]), tracks: [:])
 
     // mapping from peer's id to itself
@@ -713,6 +715,51 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
             state = .disconnected
         default:
             break
+        }
+    }
+
+    func onDisconnected() {
+        DispatchQueue.webRTC.sync {
+            peerConnectionManager.close()
+            prevLocalTracks = Array((prevLocalTracks + localTracks))
+            localTracks = []
+            let metadata = localEndpoint.metadata
+            localEndpoint = Endpoint(id: "", type: "webrtc", metadata: metadata, tracks: [:])
+            state = .awaitingConnect
+        }
+    }
+
+    func reconnect() {
+        DispatchQueue.webRTC.sync {
+            prevLocalTracks.forEach { track in
+                switch track {
+                case let track as LocalVideoTrack:
+                    let videoTrack = LocalVideoTrack(
+                        oldTrack: track,
+                        peerConnectionFactoryWrapper: peerConnectionFactoryWrapper)
+                    localTracks.append(videoTrack)
+
+                    localEndpoint = localEndpoint.withTrack(
+                        trackId: videoTrack.rtcTrack().trackId, metadata: trackContexts[track.trackId()]?.metadata,
+                        simulcastConfig: trackContexts[track.trackId()]?.simulcastConfig)
+
+                    break
+                case let track as LocalAudioTrack:
+                    let audioTrack = LocalAudioTrack(
+                        oldTrack: track, peerConnectionFactoryWrapper: peerConnectionFactoryWrapper)
+                    localTracks.append(audioTrack)
+                    localEndpoint = localEndpoint.withTrack(
+                        trackId: audioTrack.trackId(), metadata: trackContexts[track.trackId()]?.metadata,
+                        simulcastConfig: nil)
+                    break
+                default:
+                    break
+                }
+                trackContexts.removeValue(forKey: track.trackId())
+            }
+            prevLocalTracks = []
+            engineCommunication.connect(metadata: localEndpoint.metadata)
+
         }
     }
 }

--- a/packages/ios-client/Sources/MembraneRTC/PeerConnectionManager.swift
+++ b/packages/ios-client/Sources/MembraneRTC/PeerConnectionManager.swift
@@ -41,6 +41,7 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
     public func close() {
         if let pc = connection {
             pc.close()
+            self.connection = nil
         }
     }
 

--- a/packages/ios-client/Sources/MembraneRTC/Types/AuthError.swift
+++ b/packages/ios-client/Sources/MembraneRTC/Types/AuthError.swift
@@ -4,4 +4,5 @@ public enum AuthError: String, CaseIterable {
     case expired_token = "expired token"
     case room_not_found = "room not found"
     case peer_not_found = "peer not found"
+    case peer_already_connected = "peer already connected"
 }

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/EmitableEvents.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/EmitableEvents.kt
@@ -8,4 +8,7 @@ object EmitableEvents {
   const val EndpointsUpdate = "EndpointsUpdate"
   const val AudioDeviceUpdate = "AudioDeviceUpdate"
   const val BandwidthEstimation = "BandwidthEstimation"
+  const val ReconnectionRetriesLimitReached = "ReconnectionRetriesLimitReached"
+  const val ReconnectionStarted = "ReconnectionStarted"
+  const val Reconnected = "Reconnected"
 }

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -73,6 +73,22 @@ class ScreencastOptions : Record {
   val maxBandwidthInt: Int = 0
 }
 
+class ReconnectConfig : Record {
+  @Field
+  val maxAttempts: Int = 5
+
+  @Field
+  val initialDelayMs: Long = 1000
+
+  @Field
+  val delayMs: Long = 1000
+}
+
+class ConnectConfig : Record {
+  @Field
+  val reconnectConfig: ReconnectConfig = ReconnectConfig()
+}
+
 class RNFishjamClientModule : Module() {
   override fun definition() =
     ModuleDefinition {
@@ -86,7 +102,10 @@ class RNFishjamClientModule : Module() {
         "EndpointsUpdate",
         "AudioDeviceUpdate",
         "SendMediaEvent",
-        "BandwidthEstimation"
+        "BandwidthEstimation",
+        "ReconnectionRetriesLimitReached",
+        "ReconnectionStarted",
+        "Reconnected"
       )
 
       val rnFishjamClient =
@@ -112,9 +131,9 @@ class RNFishjamClientModule : Module() {
         rnFishjamClient.onActivityResult(result.requestCode, result.resultCode, result.data)
       }
 
-      AsyncFunction("connect") { url: String, peerToken: String, peerMetadata: Map<String, Any>, promise: Promise ->
+      AsyncFunction("connect") { url: String, peerToken: String, peerMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
         CoroutineScope(Dispatchers.Main).launch {
-          rnFishjamClient.connect(url, peerToken, peerMetadata, promise)
+          rnFishjamClient.connect(url, peerToken, peerMetadata, config, promise)
         }
       }
 

--- a/packages/react-native-client/ios/Events.swift
+++ b/packages/react-native-client/ios/Events.swift
@@ -7,4 +7,7 @@ struct EmitableEvents {
     static let AudioDeviceUpdate = "AudioDeviceUpdate"
     static let SendMediaEvent = "SendMediaEvent"
     static let BandwidthEstimation = "BandwidthEstimation"
+    static let ReconnectionRetriesLimitReached = "ReconnectionRetriesLimitReached"
+    static let ReconnectionStarted = "ReconnectionStarted"
+    static let Reconnected = "Reconnected"
 }

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -53,6 +53,22 @@ struct ScreencastOptions: Record {
     var maxBandwidth: RNTrackBandwidthLimit = RNTrackBandwidthLimit(0)
 }
 
+struct ReconnectConfig: Record {
+    @Field
+    var maxAttempts: Int = 5
+
+    @Field
+    var initialDelayMs: Int = 1000
+
+    @Field
+    var delayMs: Int = 1000
+}
+
+struct ConnectConfig: Record {
+    @Field
+    var reconnectConfig: ReconnectConfig = ReconnectConfig()
+}
+
 typealias RNTrackBandwidthLimit = Either<Int, [String: Int]>
 
 public class RNFishjamClientModule: Module {
@@ -67,16 +83,21 @@ public class RNFishjamClientModule: Module {
             "EndpointsUpdate",
             "AudioDeviceUpdate",
             "SendMediaEvent",
-            "BandwidthEstimation")
+            "BandwidthEstimation",
+            "ReconnectionRetriesLimitReached",
+            "ReconnectionStarted",
+            "Reconnected")
 
         let rnFishjamClient: RNFishjamClient = RNFishjamClient {
             (eventName: String, data: [String: Any]) in
             self.sendEvent(eventName, data)
         }
 
-        AsyncFunction("connect") { (url: String, peerToken: String, peerMetadata: [String: Any], promise: Promise) in
+        AsyncFunction("connect") {
+            (url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig, promise: Promise) in
             try rnFishjamClient.create()
-            rnFishjamClient.connect(url: url, peerToken: peerToken, peerMetadata: peerMetadata, promise: promise)
+            rnFishjamClient.connect(
+                url: url, peerToken: peerToken, peerMetadata: peerMetadata, config: config, promise: promise)
         }
 
         AsyncFunction("leaveRoom") {

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -12,6 +12,7 @@ import type { CameraConfig, CaptureDevice } from './hooks/useCamera';
 import type { MicrophoneConfig } from './hooks/useMicrophone';
 import type { Endpoint } from './hooks/usePeers';
 import type { ScreencastOptions } from './hooks/useScreencast';
+import type { Config } from './common/client';
 
 type InternalCameraConfig<MetadataType extends Metadata> = Partial<
   CameraConfig<MetadataType> &
@@ -26,6 +27,7 @@ type RNFishjamClient = {
     url: string,
     peerToken: string,
     peerMetadata: Metadata,
+    config: Config,
   ) => Promise<void>;
   leaveRoom: () => Promise<void>;
   startCamera: <MetadataType extends Metadata>(

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -1,12 +1,21 @@
 import { Metadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 
+export type Config = {
+  reconnectConfig?: {
+    maxAttempts?: number;
+    initialDelayMs?: number;
+    delayMs?: number;
+  };
+};
+
 export async function connect(
   url: string,
   peerToken: string,
   peerMetadata: Metadata,
+  config: Config = {},
 ) {
-  await RNFishjamClientModule.connect(url, peerToken, peerMetadata);
+  await RNFishjamClientModule.connect(url, peerToken, peerMetadata, config);
 }
 
 export async function leaveRoom() {

--- a/packages/react-native-client/src/common/eventEmitter.ts
+++ b/packages/react-native-client/src/common/eventEmitter.ts
@@ -11,6 +11,9 @@ export const ReceivableEvents = {
   AudioDeviceUpdate: 'AudioDeviceUpdate',
   SendMediaEvent: 'SendMediaEvent',
   BandwidthEstimation: 'BandwidthEstimation',
+  ReconnectionRetriesLimitReached: 'ReconnectionRetriesLimitReached',
+  ReconnectionStarted: 'ReconnectionStarted',
+  Reconnected: 'Reconnected',
 } as const;
 
 export const eventEmitter = new EventEmitter(

--- a/packages/react-native-client/src/hooks/useReconnection.ts
+++ b/packages/react-native-client/src/hooks/useReconnection.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { ReceivableEvents, eventEmitter } from '../common/eventEmitter';
+
+export type ReconnectionStatus = 'idle' | 'reconnecting' | 'error';
+
+export function useReconnection() {
+  const [reconnectionStatus, setReconnectionStatus] =
+    useState<ReconnectionStatus>('idle');
+
+  useEffect(() => {
+    const reconnectedEventListener = eventEmitter.addListener(
+      ReceivableEvents.Reconnected,
+      () => {
+        setReconnectionStatus('idle');
+      },
+    );
+
+    const reconnectionStartedEventListener = eventEmitter.addListener(
+      ReceivableEvents.ReconnectionStarted,
+      () => {
+        setReconnectionStatus('reconnecting');
+      },
+    );
+
+    const reconnectionRetriesLimitReachedEventListener =
+      eventEmitter.addListener(
+        ReceivableEvents.ReconnectionRetriesLimitReached,
+        () => {
+          setReconnectionStatus('error');
+        },
+      );
+
+    return () => {
+      reconnectedEventListener.remove();
+      reconnectionStartedEventListener.remove();
+      reconnectionRetriesLimitReachedEventListener.remove();
+    };
+  });
+
+  return { reconnectionStatus };
+}

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -38,6 +38,9 @@ export type {
 } from './hooks/useScreencast';
 export { useScreencast } from './hooks/useScreencast';
 
+export type { ReconnectionStatus } from './hooks/useReconnection';
+export { useReconnection } from './hooks/useReconnection';
+
 export {
   updateAudioTrackMetadata,
   updatePeerMetadata,


### PR DESCRIPTION
This PR adds a feature for automatic reconnection. If there is no internet the sdk will attempt to connect again with exponential backoff. User can configure the amount of attempts and the delay. User can disable this by setting max attempts to 0. 
When reconnecting we must "recreate" local tracks (if we don't do this, we'll crash the backend with duplicated tracks error). But to avoid opening up the camera and all this mess with screencast permissions etc. we're reusing track sources, so the experience is smoother.
Also app developer can use a hook to keep track of reconnection status and inform app users what's happening. 
