### PR TITLE
[FCE-212] Rename references from "endpoint" to "peer" in RN-SDK API

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -417,7 +417,7 @@ internal class FishjamClientInternal(
 
   fun updatePeerMetadata(peerMetadata: Metadata) {
     coroutineScope.launch {
-      rtcEngineCommunication.updateEndpointMetadata(peerMetadata)
+      rtcEngineCommunication.updatePeerMetadata(peerMetadata)
       localEndpoint = localEndpoint.copy(metadata = peerMetadata)
     }
   }

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/events/Event.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/events/Event.kt
@@ -116,7 +116,7 @@ data class UpdateEndpointMetadata(
     val metadata: Metadata?
   )
 
-  constructor(metadata: Metadata? = mapOf()) : this("updateEndpointMetadata", Data(metadata))
+  constructor(metadata: Metadata? = mapOf()) : this("updatePeerMetadata", Data(metadata))
 }
 
 data class UpdateTrackMetadata(

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/webrtc/RTCEngineCommunication.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/webrtc/RTCEngineCommunication.kt
@@ -48,7 +48,7 @@ internal class RTCEngineCommunication {
     sendEvent(Connect(endpointMetadata))
   }
 
-  fun updateEndpointMetadata(endpointMetadata: Metadata) {
+  fun updatePeerMetadata(endpointMetadata: Metadata) {
     sendEvent(UpdateEndpointMetadata(endpointMetadata))
   }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -206,7 +206,7 @@ public class FishjamClient {
     * callback `onPeerUpdated` will be triggered for other peers in the room.
     */
     public func updatePeerMetadata(peerMetadata: Metadata) {
-        webrtcClient.updateEndpointMetadata(metadata: peerMetadata)
+        webrtcClient.updatePeerMetadata(metadata: peerMetadata)
     }
 
     /**

--- a/packages/ios-client/Sources/MembraneRTC/MembraneRTC.swift
+++ b/packages/ios-client/Sources/MembraneRTC/MembraneRTC.swift
@@ -355,9 +355,9 @@ public class MembraneRTC: MulticastDelegate<MembraneRTCDelegate>, ObservableObje
      If the metadata is different from what is already tracked in the room, the optional
      callback `onEndpointUpdated` will be triggered for other peers in the room.
      */
-    public func updateEndpointMetadata(metadata: Metadata) {
+    public func updatePeerMetadata(metadata: Metadata) {
         DispatchQueue.webRTC.sync {
-            engineCommunication.updateEndpointMetadata(metadata: metadata)
+            engineCommunication.updatePeerMetadata(metadata: metadata)
             localEndpoint = localEndpoint.with(metadata: metadata)
         }
     }

--- a/packages/ios-client/Sources/MembraneRTC/RTCEngineCommunication.swift
+++ b/packages/ios-client/Sources/MembraneRTC/RTCEngineCommunication.swift
@@ -12,7 +12,7 @@ internal class RTCEngineCommunication {
         sendEvent(event: ConnectEvent(metadata: metadata))
     }
 
-    func updateEndpointMetadata(metadata: Metadata) {
+    func updatePeerMetadata(metadata: Metadata) {
         sendEvent(event: UpdateEndpointMetadata(metadata: metadata))
     }
 

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/EmitableEvents.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/EmitableEvents.kt
@@ -5,7 +5,7 @@ object EmitableEvents {
   const val IsMicrophoneOn = "IsMicrophoneOn"
   const val IsScreencastOn = "IsScreencastOn"
   const val SimulcastConfigUpdate = "SimulcastConfigUpdate"
-  const val EndpointsUpdate = "EndpointsUpdate"
+  const val PeersUpdate = "PeersUpdate"
   const val AudioDeviceUpdate = "AudioDeviceUpdate"
   const val BandwidthEstimation = "BandwidthEstimation"
 }

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
@@ -367,7 +367,7 @@ class RNFishjamClient(
     }
   }
 
-  fun getEndpoints(): List<Map<String, Any?>> =
+  fun getPeers(): List<Map<String, Any?>> =
     getAllPeers().map { endpoint ->
       mapOf(
         "id" to endpoint.id,
@@ -435,7 +435,7 @@ class RNFishjamClient(
     }
   }
 
-  fun updateEndpointMetadata(metadata: Metadata) {
+  fun updatePeerMetadata(metadata: Metadata) {
     ensureConnected()
     fishjamClient.updatePeerMetadata(metadata)
   }
@@ -716,8 +716,8 @@ class RNFishjamClient(
   }
 
   private fun emitEndpoints() {
-    val eventName = EmitableEvents.EndpointsUpdate
-    val map = mapOf(eventName to getEndpoints())
+    val eventName = EmitableEvents.PeersUpdate
+    val map = mapOf(eventName to getPeers())
     emitEvent(eventName, map)
   }
 

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -83,7 +83,7 @@ class RNFishjamClientModule : Module() {
         "IsMicrophoneOn",
         "IsScreencastOn",
         "SimulcastConfigUpdate",
-        "EndpointsUpdate",
+        "PeersUpdate",
         "AudioDeviceUpdate",
         "SendMediaEvent",
         "BandwidthEstimation"
@@ -194,15 +194,15 @@ class RNFishjamClientModule : Module() {
         return@Property rnFishjamClient.isScreencastOn
       }
 
-      AsyncFunction("getEndpoints") Coroutine { ->
+      AsyncFunction("getPeers") Coroutine { ->
         withContext(Dispatchers.Main) {
-          rnFishjamClient.getEndpoints()
+          rnFishjamClient.getPeers()
         }
       }
 
-      AsyncFunction("updateEndpointMetadata") Coroutine { metadata: Map<String, Any> ->
+      AsyncFunction("updatePeerMetadata") Coroutine { metadata: Map<String, Any> ->
         withContext(Dispatchers.Main) {
-          rnFishjamClient.updateEndpointMetadata(metadata)
+          rnFishjamClient.updatePeerMetadata(metadata)
         }
       }
 

--- a/packages/react-native-client/ios/Events.swift
+++ b/packages/react-native-client/ios/Events.swift
@@ -3,7 +3,7 @@ struct EmitableEvents {
     static let IsMicrophoneOn = "IsMicrophoneOn"
     static let IsScreencastOn = "IsScreencastOn"
     static let SimulcastConfigUpdate = "SimulcastConfigUpdate"
-    static let EndpointsUpdate = "EndpointsUpdate"
+    static let PeersUpdate = "PeersUpdate"
     static let AudioDeviceUpdate = "AudioDeviceUpdate"
     static let SendMediaEvent = "SendMediaEvent"
     static let BandwidthEstimation = "BandwidthEstimation"

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -576,7 +576,7 @@ class RNFishjamClient: FishjamClientListener {
         return trackId == localAudioTrack?.trackId() || trackId == localVideoTrack?.trackId()
             || trackId == localScreencastTrack?.trackId()
     }
-    func getEndpoints() -> [[String: Any]] {
+    func getPeers() -> [[String: Any]] {
         MembraneRoom.sharedInstance.endpoints.values.sorted(by: { $0.order < $1.order }).map {
             (p) -> Dictionary in
             let videoTracks = p.videoTracks.keys.map { trackId in
@@ -650,7 +650,7 @@ class RNFishjamClient: FishjamClientListener {
         ]
     }
 
-    func updateEndpointMetadata(metadata: [String: Any]) throws {
+    func updatePeerMetadata(metadata: [String: Any]) throws {
         try ensureConnected()
         fishjamClient?.updatePeerMetadata(peerMetadata: metadata.toMetadata())
     }
@@ -938,8 +938,8 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func emitEndpoints() {
-        let eventName = EmitableEvents.EndpointsUpdate
-        let EndpointsUpdateMap = [eventName: getEndpoints()]
+        let eventName = EmitableEvents.PeersUpdate
+        let EndpointsUpdateMap = [eventName: getPeers()]
         emitEvent(name: eventName, data: EndpointsUpdateMap)
     }
 

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -64,7 +64,7 @@ public class RNFishjamClientModule: Module {
             "IsMicrophoneOn",
             "IsScreencastOn",
             "SimulcastConfigUpdate",
-            "EndpointsUpdate",
+            "PeersUpdate",
             "AudioDeviceUpdate",
             "SendMediaEvent",
             "BandwidthEstimation")
@@ -127,12 +127,12 @@ public class RNFishjamClientModule: Module {
             return rnFishjamClient.isScreensharingEnabled
         }
 
-        AsyncFunction("getEndpoints") {
-            rnFishjamClient.getEndpoints()
+        AsyncFunction("getPeers") {
+            rnFishjamClient.getPeers()
         }
 
-        AsyncFunction("updateEndpointMetadata") { (metadata: [String: Any]) in
-            try rnFishjamClient.updateEndpointMetadata(metadata: metadata)
+        AsyncFunction("updatePeerMetadata") { (metadata: [String: Any]) in
+            try rnFishjamClient.updatePeerMetadata(metadata: metadata)
         }
 
         AsyncFunction("updateVideoTrackMetadata") { (metadata: [String: Any]) in

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -10,7 +10,7 @@ import type {
 } from './types';
 import type { CameraConfig, CaptureDevice } from './hooks/useCamera';
 import type { MicrophoneConfig } from './hooks/useMicrophone';
-import type { Endpoint } from './hooks/usePeers';
+import type { Peer } from './hooks/usePeers';
 import type { ScreencastOptions } from './hooks/useScreencast';
 
 type InternalCameraConfig<MetadataType extends Metadata> = Partial<
@@ -46,18 +46,14 @@ type RNFishjamClient = {
     screencastOptions: Partial<ScreencastOptions<MetadataType>>,
   ) => Promise<void>;
   isScreencastOn: boolean;
-  getEndpoints: <
-    EndpointMetadataType extends Metadata,
+  getPeers: <
+    PeerMetadataType extends Metadata,
     VideoTrackMetadataType extends Metadata,
     AudioTrackMetadataType extends Metadata,
   >() => Promise<
-    Endpoint<
-      EndpointMetadataType,
-      VideoTrackMetadataType,
-      AudioTrackMetadataType
-    >[]
+    Peer<PeerMetadataType, VideoTrackMetadataType, AudioTrackMetadataType>[]
   >;
-  updateEndpointMetadata: <MetadataType extends Metadata>(
+  updatePeerMetadata: <MetadataType extends Metadata>(
     metadata: MetadataType,
   ) => Promise<void>;
   updateVideoTrackMetadata: <MetadataType extends Metadata>(

--- a/packages/react-native-client/src/common/eventEmitter.ts
+++ b/packages/react-native-client/src/common/eventEmitter.ts
@@ -7,7 +7,7 @@ export const ReceivableEvents = {
   IsMicrophoneOn: 'IsMicrophoneOn',
   IsScreencastOn: 'IsScreencastOn',
   SimulcastConfigUpdate: 'SimulcastConfigUpdate',
-  EndpointsUpdate: 'EndpointsUpdate',
+  PeersUpdate: 'PeersUpdate',
   AudioDeviceUpdate: 'AudioDeviceUpdate',
   SendMediaEvent: 'SendMediaEvent',
   BandwidthEstimation: 'BandwidthEstimation',

--- a/packages/react-native-client/src/common/metadata.ts
+++ b/packages/react-native-client/src/common/metadata.ts
@@ -5,10 +5,10 @@ import RNFishjamClientModule from '../RNFishjamClientModule';
  * a function that updates endpoints's metadata on the server
  * @param metadata a map `string -> any` containing user's track metadata to be sent to the server
  */
-export async function updatePeerMetadata<EndpointMetadataType extends Metadata>(
-  metadata: EndpointMetadataType,
+export async function updatePeerMetadata<PeerMetadataType extends Metadata>(
+  metadata: PeerMetadataType,
 ) {
-  await RNFishjamClientModule.updateEndpointMetadata(metadata);
+  await RNFishjamClientModule.updatePeerMetadata(metadata);
 }
 
 /**

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -36,50 +36,40 @@ export type Track<MetadataType extends Metadata> = {
  */
 export type EncodingReason = 'other' | 'encoding_inactive' | 'low_bandwidth';
 
-export type EndpointsUpdateEvent<
+export type PeersUpdateEvent<
   MetadataType extends Metadata,
   VideoTrackMetadataType extends Metadata,
   AudioTrackMetadataType extends Metadata,
 > = {
-  EndpointsUpdate: Endpoint<
+  PeersUpdate: Peer<
     MetadataType,
     VideoTrackMetadataType,
     AudioTrackMetadataType
   >[];
 };
 
-export type Endpoint<
+export type Peer<
   MetadataType extends Metadata,
   VideoTrackMetadataType extends Metadata,
   AudioTrackMetadataType extends Metadata,
 > = {
   /**
-   *  id used to identify an endpoint
+   *  id used to identify a peer
    */
   id: string;
   /**
-   * used to indicate endpoint type.
-   */
-  type: string;
-  /**
-   * whether the endpoint is local or remote
+   * whether the peer is local or remote
    */
   isLocal: boolean;
   /**
-   * a map `string -> any` containing endpoint metadata from the server
+   * a map `string -> any` containing peer metadata from the server
    */
   metadata: MetadataType;
   /**
-   * a list of endpoints's video and audio tracks
+   * a list of peers's video and audio tracks
    */
   tracks: Track<VideoTrackMetadataType | AudioTrackMetadataType>[];
 };
-
-export type Peer<
-  MetadataType extends Metadata,
-  VideoTrackMetadataType extends Metadata,
-  AudioTrackMetadataType extends Metadata,
-> = Endpoint<MetadataType, VideoTrackMetadataType, AudioTrackMetadataType>;
 
 /**
  * This hook provides live updates of room peers.
@@ -95,26 +85,26 @@ export function usePeers<
   >([]);
 
   useEffect(() => {
-    async function updateEndpoints() {
-      const endpoints = await RNFishjamClientModule.getEndpoints<
+    async function updatePeers() {
+      const peers = await RNFishjamClientModule.getPeers<
         MetadataType,
         VideoTrackMetadataType,
         AudioTrackMetadataType
       >();
-      setPeers(endpoints);
+      setPeers(peers);
     }
 
     const eventListener = eventEmitter.addListener<
-      EndpointsUpdateEvent<
+      PeersUpdateEvent<
         MetadataType,
         VideoTrackMetadataType,
         AudioTrackMetadataType
       >
-    >(ReceivableEvents.EndpointsUpdate, (event) => {
-      setPeers(event.EndpointsUpdate);
+    >(ReceivableEvents.PeersUpdate, (event) => {
+      setPeers(event.PeersUpdate);
     });
 
-    updateEndpoints();
+    updatePeers();
     return () => eventListener.remove();
   }, []);
 


### PR DESCRIPTION
React Native SDK exports functions/types that reference both Peers and Endpoints. From an end user perspective, they are basically the same thing. So, let's rename/remove references to them from public API.