### PR TITLE
Fix room manager audio tracks

### DIFF
--- a/examples/video-chat/screens/RoomScreen.tsx
+++ b/examples/video-chat/screens/RoomScreen.tsx
@@ -53,7 +53,7 @@ const RoomScreen = ({ navigation, route }: Props) => {
     () =>
       peers.flatMap((peer) =>
         peer.tracks.filter(
-          (t) => t.metadata.type !== 'audio' && (t.metadata.active ?? true),
+          (t) => t.type == 'Video' && (t.metadata.active ?? true),
         ),
       ),
     [peers],

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -659,7 +659,7 @@ internal class FishjamClientInternal(
         return
       }
 
-    val updatedTracks = mutableMapOf<String, Track>()
+    val updatedTracks = endpoint.tracks.toMutableMap()
 
     for ((trackId, trackData) in tracks) {
       var track = endpoint.tracks.values.firstOrNull { track -> track.getRTCEngineId() == trackId }
@@ -688,8 +688,8 @@ internal class FishjamClientInternal(
       }
 
     trackIds.forEach { trackId ->
-      val track = endpoint.tracks[trackId] ?: return
-      endpoint = endpoint.removeTrack(trackId)
+      val track = endpoint.tracks.values.firstOrNull { it.getRTCEngineId() == trackId } ?: return
+      endpoint = endpoint.removeTrack(track.id())
       this.listener.onTrackRemoved(track)
     }
     remoteEndpoints[endpointId] = endpoint


### PR DESCRIPTION
To reproduce:
- run room manager
- add some peers with video AND audio tracks
- connect mobile to the room
- some tracks will be black squares

What happened? The old videoroom was sending track metadata which contained "type" value set to "audio" for audio track. The new videoroom doesn't send any metadata. So the example app treated audio tracks like video track.

Fixed by checking the type of the track, not metadata.

I'm not sure if this is the bug that @mironiasty have experienced but after fixing that everything works ok for me - I can see all the video tracks, no black squares and I can turn on/off some of the tracks.