### PR TITLE
[FCE-402] Use branded type as camera id

### DIFF
--- a/packages/react-native-client/src/components/VideoPreviewView.tsx
+++ b/packages/react-native-client/src/components/VideoPreviewView.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ViewStyle } from 'react-native';
 
 import { VideoLayout } from '../types';
+import { CaptureDeviceId } from '../hooks/useCamera';
 
 export type VideoPreviewViewProps = {
   /**
@@ -17,7 +18,7 @@ export type VideoPreviewViewProps = {
    * Id of the camera used for preview. Get available cameras with `getCaptureDevices()` function.
    * @default the first front camera
    */
-  captureDeviceId?: string;
+  captureDeviceId?: CaptureDeviceId;
 };
 
 const NativeView: React.ComponentType<VideoPreviewViewProps> =

--- a/packages/react-native-client/src/hooks/useCamera.ts
+++ b/packages/react-native-client/src/hooks/useCamera.ts
@@ -3,6 +3,7 @@ import { Platform } from 'react-native';
 
 import {
   BandwidthLimit,
+  Brand,
   Metadata,
   SimulcastConfig,
   TrackBandwidthLimit,
@@ -13,9 +14,10 @@ import { ReceivableEvents, eventEmitter } from '../common/eventEmitter';
 
 type IsCameraOnEvent = { IsCameraOn: boolean };
 type SimulcastConfigUpdateEvent = SimulcastConfig;
+export type CaptureDeviceId = Brand<string, 'CaptureDeviceId'>;
 
 export type CaptureDevice = {
-  id: string;
+  id: CaptureDeviceId;
   name: string;
   isFrontFacing: boolean;
   isBackFacing: boolean;
@@ -68,7 +70,7 @@ export type CameraConfig<MetadataType extends Metadata> = {
    * You can switch the cameras later with `flipCamera`/`switchCamera` functions.
    * @default the first front camera
    */
-  captureDeviceId?: string;
+  captureDeviceId?: CaptureDeviceId;
 };
 
 type StartCameraConfig = <CameraConfigMetadataType extends Metadata>(
@@ -184,7 +186,7 @@ export function useCamera() {
    * Function that switches to the specified camera. By default the front camera is used.
    * @returns A promise that resolves when camera is switched.
    */
-  const switchCamera = useCallback(async (captureDeviceId: string) => {
+  const switchCamera = useCallback(async (captureDeviceId: CaptureDeviceId) => {
     await RNFishjamClientModule.switchCamera(captureDeviceId);
   }, []);
 

--- a/packages/react-native-client/src/types.ts
+++ b/packages/react-native-client/src/types.ts
@@ -38,3 +38,7 @@ export type SimulcastBandwidthLimit = Record<TrackEncoding, BandwidthLimit>;
  * A type describing bandwidth limitation of a track, including simulcast and non-simulcast tracks. Can be `BandwidthLimit` or `SimulcastBandwidthLimit`.
  */
 export type TrackBandwidthLimit = BandwidthLimit | SimulcastBandwidthLimit;
+
+// branded types are useful for restricting where given value can be passed
+declare const brand: unique symbol;
+export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };


### PR DESCRIPTION
## Description

Branded types are nice tool for restricting type of values that can be passed into functions.
This change converts camera id into such type. This way, when switching camera, developer won't be able to pass arbitrary string. It will be possible to pass only id we are allowing to use.

## Motivation and Context

Add better restriction to API


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

