### PR TITLE
[FCE-469] Handle non-JSON connection errors and warn

### DIFF
--- a/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -41,7 +41,13 @@ async function getFishjamServer(
     `${url}${roomName.trim()}/users/${userName.trim()}`,
   );
   if (!response.ok) {
-    throw new Error(JSON.stringify(await response.json()));
+    const responseText = await response.text();
+    console.warn(
+      'get_fishjam_failed',
+      `statusCode=${response.status}`,
+      `message=${responseText}`,
+    );
+    throw new Error(responseText);
   }
   const tokenData = (await response.json()) as {
     url: string;


### PR DESCRIPTION
## Description

Connection response can contain non-JSON data, e.g. `Bad Gateway`, we now return raw response because of that. The error is now also logged.

## Motivation and Context

This change is made to improve developer experience of using the example application.

## How has this been tested?

Manual testing on the Android emulator.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)

<img width="529" alt="image" src="https://github.com/user-attachments/assets/9c193b8c-68da-41dd-94db-99cf8b660de1">

<img width="529" alt="image" src="https://github.com/user-attachments/assets/0d1591bd-319a-4ae8-8e29-5b3224432b54">
