### PR TITLE
Accept Fishjam's path as Room Manager's

### DIFF
--- a/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/video-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -28,15 +28,16 @@ async function getFishjamServer(
   roomName: string,
   userName: string,
 ) {
-  // in case user copied url from admin panel
-  const urlWithoutParams = roomManagerUrl.replace(
-    '/*roomName*/users/*username*',
-    '',
-  );
-  // trim slash from end
-  const url = urlWithoutParams.endsWith('/')
-    ? urlWithoutParams
-    : urlWithoutParams + '/';
+  const ensureUrlEndsWith = (url: string, ending: string) =>
+    url.endsWith(ending) ? url : url + ending;
+
+  let url = roomManagerUrl.trim();
+  // in case user copied url from the main Fishjam panel
+  url = url.replace('/*roomName*/users/*username*', '');
+  url = ensureUrlEndsWith(url, '/');
+  // in case user copied url from the app view
+  url = ensureUrlEndsWith(url, 'room-manager/');
+
   const response = await fetch(
     `${url}${roomName.trim()}/users/${userName.trim()}`,
   );


### PR DESCRIPTION
## Description

This change provides better heuristics for fixing copy-pasted connection URLs.

## Motivation and Context

There are three places that the user can get the connection URL:

- admin panel main page
- app view
- self-crafted from the app view

URL entry now allows for the app-view-formatted URL, by appending `/room-manager`. We also trim the string as a bonus.

Without this, the user would get a very misleading `Not Found` error from the Fishjam instance.

## How has this been tested?

Manual on both Android and iOS emulator/simulator.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
