### PR TITLE
[FCE-293] Remove external fonts

### DIFF
--- a/examples/fishjam-chat/components/Typo.tsx
+++ b/examples/fishjam-chat/components/Typo.tsx
@@ -1,9 +1,3 @@
-import {
-  NotoSans_400Regular,
-  NotoSans_500Medium,
-  NotoSans_600SemiBold,
-  useFonts,
-} from '@expo-google-fonts/noto-sans';
 import React, { type ReactNode } from 'react';
 import {
   Dimensions,
@@ -73,12 +67,6 @@ export default function Typo({
   style,
   ...textProps
 }: TypoProps) {
-  useFonts({
-    NotoSans_400Regular,
-    NotoSans_500Medium,
-    NotoSans_600SemiBold,
-  });
-
   const getStyleForVariant = [{ color }, getFontVariant(variant)];
 
   return (
@@ -90,27 +78,27 @@ export default function Typo({
 
 const Headlines = StyleSheet.create({
   h1: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 68,
     lineHeight: 76,
   },
   h2: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 48,
     lineHeight: 54,
   },
   h3: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 36,
     lineHeight: 48,
   },
   h4: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 24,
     lineHeight: 36,
   },
   h5: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 18,
     lineHeight: 28,
   },
@@ -118,27 +106,27 @@ const Headlines = StyleSheet.create({
 
 const HeadlinesSmall = StyleSheet.create({
   h1: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 42,
     lineHeight: 48,
   },
   h2: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 36,
     lineHeight: 42,
   },
   h3: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 24,
     lineHeight: 32,
   },
   h4: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 20,
     lineHeight: 32,
   },
   h5: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 18,
     lineHeight: 28,
   },
@@ -146,29 +134,29 @@ const HeadlinesSmall = StyleSheet.create({
 
 const TextStyles = StyleSheet.create({
   bodyBig: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 20,
     lineHeight: 36,
   },
   bodySmall: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 16,
     lineHeight: 28,
   },
   label: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 12,
     lineHeight: 16,
   },
   caption: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 18,
     lineHeight: 24,
     letterSpacing: 1,
     textTransform: 'uppercase',
   },
   button: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 18,
     lineHeight: 24,
     letterSpacing: 0.5,
@@ -177,29 +165,29 @@ const TextStyles = StyleSheet.create({
 
 const TextStylesSmall = StyleSheet.create({
   bodyBig: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 18,
     lineHeight: 32,
   },
   bodySmall: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 16,
     lineHeight: 28,
   },
   label: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 12,
     lineHeight: 16,
   },
   caption: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 18,
     lineHeight: 24,
     letterSpacing: 1,
     textTransform: 'uppercase',
   },
   button: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 18,
     lineHeight: 24,
     letterSpacing: 0.5,
@@ -208,22 +196,22 @@ const TextStylesSmall = StyleSheet.create({
 
 const TextStylesCustom = StyleSheet.create({
   videoLabel: {
-    fontFamily: 'NotoSans_500Medium',
+    fontWeight: '500',
     fontSize: 14,
     lineHeight: 18,
   },
   chatRegular: {
-    fontFamily: 'NotoSans_400Regular',
+    fontWeight: '400',
     fontSize: 14,
     lineHeight: 21,
   },
   chatSemibold: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 14,
     lineHeight: 21,
   },
   chatTitle: {
-    fontFamily: 'NotoSans_600SemiBold',
+    fontWeight: '600',
     fontSize: 16,
     lineHeight: 24,
   },
@@ -231,7 +219,6 @@ const TextStylesCustom = StyleSheet.create({
 
 export const TextInputTextStyle = StyleSheet.create({
   body: {
-    fontFamily: TextStylesSmall.bodySmall.fontFamily,
     fontSize: TextStylesSmall.bodySmall.fontSize,
   },
 });

--- a/examples/fishjam-chat/package.json
+++ b/examples/fishjam-chat/package.json
@@ -15,7 +15,6 @@
     "lint:check": "sh ./scripts/lint_check.sh"
   },
   "dependencies": {
-    "@expo-google-fonts/noto-sans": "^0.2.3",
     "@fishjam-cloud/react-native-client": "*",
     "@gorhom/bottom-sheet": "^4",
     "@notifee/react-native": "^7.8.2",
@@ -25,7 +24,6 @@
     "expo": "^50.0.20",
     "expo-camera": "^14.0.4",
     "expo-device": "^5.9.3",
-    "expo-font": "^11.10.2",
     "react": "18.3.1",
     "react-native": "0.73.4",
     "react-native-gesture-handler": "~2.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2788,13 +2788,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo-google-fonts/noto-sans@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "@expo-google-fonts/noto-sans@npm:0.2.3"
-  checksum: 10c0/41342240a58ce0a2c7d98e1fbef79c9e6c336092e5b23235ea913075d2debae5438d9f94db84b69debe7e25efbaad5f68dad88a50882d32a6f6acc20ee9b16eb
-  languageName: node
-  linkType: hard
-
 "@expo/bunyan@npm:^4.0.0":
   version: 4.0.0
   resolution: "@expo/bunyan@npm:4.0.0"
@@ -3315,7 +3308,6 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.4"
     "@babel/runtime": "npm:^7.25.6"
-    "@expo-google-fonts/noto-sans": "npm:^0.2.3"
     "@fishjam-cloud/react-native-client": "npm:*"
     "@gorhom/bottom-sheet": "npm:^4"
     "@notifee/react-native": "npm:^7.8.2"
@@ -3337,7 +3329,6 @@ __metadata:
     expo: "npm:^50.0.20"
     expo-camera: "npm:^14.0.4"
     expo-device: "npm:^5.9.3"
-    expo-font: "npm:^11.10.2"
     jest: "npm:^29.6.3"
     lint-staged: "npm:^15.2.10"
     react: "npm:18.3.1"
@@ -10850,7 +10841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-font@npm:^11.10.2, expo-font@npm:~11.10.3":
+"expo-font@npm:~11.10.3":
   version: 11.10.3
   resolution: "expo-font@npm:11.10.3"
   dependencies:


### PR DESCRIPTION
## Description

This task remove external font usage. This will simplify expo migration. Also we don't really need these fonts in app.

## Motivation and Context

Make example app simpler.

## How has this been tested?

Run app and verify that fonts are still displayed

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
