### PR TITLE
[FCE-532] Rename `connect` to `joinRoom`

### DIFF
--- a/examples/fishjam-chat/navigators/AppNavigator.tsx
+++ b/examples/fishjam-chat/navigators/AppNavigator.tsx
@@ -17,7 +17,7 @@ export type AppRootStackParamList = {
   Preview: {
     userName?: string;
     fishjamUrl: string;
-    peerToken: string;
+    participantToken: string;
   };
   Room: {
     isCameraOn: boolean;

--- a/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -85,7 +85,7 @@ export default function ConnectScreen({ navigation }: Props) {
       navigation.navigate('Preview', {
         userName,
         fishjamUrl,
-        peerToken: token,
+        participantToken: token,
       });
     } catch (e) {
       const message =

--- a/examples/fishjam-chat/screens/ConnectWithTokenScreen.tsx
+++ b/examples/fishjam-chat/screens/ConnectWithTokenScreen.tsx
@@ -33,7 +33,7 @@ const { URL_INPUT, TOKEN_INPUT, CONNECT_BUTTON } = connectScreenLabels;
 const ConnectScreen = ({ navigation }: Props) => {
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
-  const [peerToken, onChangePeerToken] = useState(
+  const [participantToken, onChangeParticipantToken] = useState(
     process.env.EXPO_PUBLIC_FISHJAM_TOKEN ?? '',
   );
   const [fishjamUrl, onChangeFishjamUrl] = useState(
@@ -47,7 +47,7 @@ const ConnectScreen = ({ navigation }: Props) => {
       setConnectionError(null);
       navigation.navigate('Preview', {
         fishjamUrl: fishjamUrl.trim(),
-        peerToken: peerToken.trim(),
+        participantToken: participantToken.trim(),
       });
     } catch (e) {
       const message =
@@ -75,8 +75,8 @@ const ConnectScreen = ({ navigation }: Props) => {
             placeholder="Fishjam URL"
           />
           <TextInput
-            onChangeText={onChangePeerToken}
-            defaultValue={peerToken}
+            onChangeText={onChangeParticipantToken}
+            defaultValue={participantToken}
             accessibilityLabel={TOKEN_INPUT}
             placeholder="Peer Token"
           />
@@ -85,7 +85,7 @@ const ConnectScreen = ({ navigation }: Props) => {
             onPress={onTapConnectButton}
             accessibilityLabel={CONNECT_BUTTON}
           />
-          <QRCodeScanner onCodeScanned={onChangePeerToken} />
+          <QRCodeScanner onCodeScanned={onChangeParticipantToken} />
         </KeyboardAvoidingView>
       </SafeAreaView>
     </DismissKeyboard>

--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -2,7 +2,7 @@ import {
   CaptureDevice,
   useCamera,
   useMicrophone,
-  connect,
+  joinRoom,
   VideoPreviewView,
 } from '@fishjam-cloud/react-native-client';
 import BottomSheet from '@gorhom/bottom-sheet';
@@ -93,9 +93,9 @@ function PreviewScreen({
   }, [getCaptureDevices, startCamera]);
 
   const onJoinPressed = async () => {
-    await connect<ParticipantMetadata>(
+    await joinRoom<ParticipantMetadata>(
       route.params.fishjamUrl,
-      route.params.peerToken,
+      route.params.participantToken,
       {
         name: route.params.userName,
       },

--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -4,13 +4,13 @@ import WebRTC
 public struct ConnectConfig {
     var websocketUrl: String
     var token: String
-    var peerMetadata: Metadata
+    var participantMetadata: Metadata
     var reconnectConfig: ReconnectConfig
 
-    public init(websocketUrl: String, token: String, peerMetadata: Metadata, reconnectConfig: ReconnectConfig) {
+    public init(websocketUrl: String, token: String, participantMetadata: Metadata, reconnectConfig: ReconnectConfig) {
         self.websocketUrl = websocketUrl + "/socket/peer/websocket"
         self.token = token
-        self.peerMetadata = peerMetadata
+        self.participantMetadata = participantMetadata
         self.reconnectConfig = reconnectConfig
     }
 }

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
@@ -231,8 +231,8 @@ class RNFishjamClient(
 
   fun connect(
     url: String,
-    peerToken: String,
-    peerMetadata: Map<String, Any>,
+    participantToken: String,
+    participantMetadata: Map<String, Any>,
     config: ConnectConfig,
     promise: Promise
   ) {
@@ -241,8 +241,8 @@ class RNFishjamClient(
     fishjamClient.connect(
       com.fishjamcloud.client.ConnectConfig(
         url,
-        peerToken,
-        peerMetadata,
+        participantToken,
+        participantMetadata,
         ReconnectConfig(
           config.reconnectConfig.maxAttempts,
           config.reconnectConfig.initialDelayMs,

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClient.kt
@@ -229,7 +229,7 @@ class RNFishjamClient(
     }
   }
 
-  fun connect(
+  fun joinRoom(
     url: String,
     participantToken: String,
     participantMetadata: Map<String, Any>,

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -143,7 +143,9 @@ class RNFishjamClientModule : Module() {
         rnFishjamClient.onActivityResult(result.requestCode, result.resultCode, result.data)
       }
 
-      AsyncFunction("joinRoom") { url: String, participantToken: String, participantMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
+      AsyncFunction(
+        "joinRoom"
+      ) { url: String, participantToken: String, participantMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
         CoroutineScope(Dispatchers.Main).launch {
           rnFishjamClient.joinRoom(url, participantToken, participantMetadata, config, promise)
         }

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -143,9 +143,9 @@ class RNFishjamClientModule : Module() {
         rnFishjamClient.onActivityResult(result.requestCode, result.resultCode, result.data)
       }
 
-      AsyncFunction("connect") { url: String, participantToken: String, participantMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
+      AsyncFunction("joinRoom") { url: String, participantToken: String, participantMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
         CoroutineScope(Dispatchers.Main).launch {
-          rnFishjamClient.connect(url, participantToken, participantMetadata, config, promise)
+          rnFishjamClient.joinRoom(url, participantToken, participantMetadata, config, promise)
         }
       }
 

--- a/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/org/membraneframework/reactnative/RNFishjamClientModule.kt
@@ -143,9 +143,9 @@ class RNFishjamClientModule : Module() {
         rnFishjamClient.onActivityResult(result.requestCode, result.resultCode, result.data)
       }
 
-      AsyncFunction("connect") { url: String, peerToken: String, peerMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
+      AsyncFunction("connect") { url: String, participantToken: String, participantMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
         CoroutineScope(Dispatchers.Main).launch {
-          rnFishjamClient.connect(url, peerToken, peerMetadata, config, promise)
+          rnFishjamClient.connect(url, participantToken, participantMetadata, config, promise)
         }
       }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -176,7 +176,10 @@ class RNFishjamClient: FishjamClientListener {
         join()
     }
 
-    func joinRoom(url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) {
+    func joinRoom(
+        url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig,
+        promise: Promise
+    ) {
         connectPromise = promise
         localUserMetadata = participantMetadata.toMetadata()
 
@@ -186,7 +189,8 @@ class RNFishjamClient: FishjamClientListener {
 
         RNFishjamClient.fishjamClient?.connect(
             config: FishjamCloudClient.ConnectConfig(
-                websocketUrl: url, token: participantToken, participantMetadata: .init(participantMetadata), reconnectConfig: reconnectConfig
+                websocketUrl: url, token: participantToken, participantMetadata: .init(participantMetadata),
+                reconnectConfig: reconnectConfig
             ))
 
     }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -176,9 +176,9 @@ class RNFishjamClient: FishjamClientListener {
         joinRoom()
     }
 
-    func connect(url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig, promise: Promise) {
+    func connect(url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) {
         connectPromise = promise
-        localUserMetadata = peerMetadata.toMetadata()
+        localUserMetadata = participantMetadata.toMetadata()
 
         let reconnectConfig = FishjamCloudClient.ReconnectConfig(
             maxAttempts: config.reconnectConfig.maxAttempts, initialDelayMs: config.reconnectConfig.initialDelayMs,
@@ -186,7 +186,7 @@ class RNFishjamClient: FishjamClientListener {
 
         RNFishjamClient.fishjamClient?.connect(
             config: FishjamCloudClient.ConnectConfig(
-                websocketUrl: url, token: peerToken, peerMetadata: .init(peerMetadata), reconnectConfig: reconnectConfig
+                websocketUrl: url, token: participantToken, participantMetadata: .init(participantMetadata), reconnectConfig: reconnectConfig
             ))
 
     }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -173,10 +173,10 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func onAuthSuccess() {
-        joinRoom()
+        join()
     }
 
-    func connect(url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) {
+    func joinRoom(url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) {
         connectPromise = promise
         localUserMetadata = participantMetadata.toMetadata()
 
@@ -191,7 +191,7 @@ class RNFishjamClient: FishjamClientListener {
 
     }
 
-    func joinRoom() {
+    func join() {
         RNFishjamClient.fishjamClient?.join(peerMetadata: localUserMetadata)
     }
 

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -99,7 +99,7 @@ public class RNFishjamClientModule: Module {
 
         AsyncFunction("connect") {
             (url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) in
-            rnFishjamClient.connect(
+            rnFishjamClient.joinRoom(
                 url: url, participantToken: participantToken, participantMetadata: participantMetadata, config: config, promise: promise)
         }
 

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -98,9 +98,9 @@ public class RNFishjamClientModule: Module {
         }()
 
         AsyncFunction("connect") {
-            (url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig, promise: Promise) in
+            (url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) in
             rnFishjamClient.connect(
-                url: url, peerToken: peerToken, peerMetadata: peerMetadata, config: config, promise: promise)
+                url: url, participantToken: participantToken, participantMetadata: participantMetadata, config: config, promise: promise)
         }
 
         AsyncFunction("leaveRoom") {

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -98,9 +98,13 @@ public class RNFishjamClientModule: Module {
         }()
 
         AsyncFunction("connect") {
-            (url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig, promise: Promise) in
+            (
+                url: String, participantToken: String, participantMetadata: [String: Any], config: ConnectConfig,
+                promise: Promise
+            ) in
             rnFishjamClient.joinRoom(
-                url: url, participantToken: participantToken, participantMetadata: participantMetadata, config: config, promise: promise)
+                url: url, participantToken: participantToken, participantMetadata: participantMetadata, config: config,
+                promise: promise)
         }
 
         AsyncFunction("leaveRoom") {

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -13,8 +13,8 @@ type Metadata = { [key: string]: any };
 type RNFishjamClient = {
   connect: (
     url: string,
-    peerToken: string,
-    peerMetadata: Metadata,
+    participantToken: string,
+    participantMetadata: Metadata,
     config: ConnectionConfig,
   ) => Promise<void>;
   leaveRoom: () => Promise<void>;

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -11,7 +11,7 @@ import type { ConnectionConfig } from './common/client';
 type Metadata = { [key: string]: any };
 
 type RNFishjamClient = {
-  connect: (
+  joinRoom: (
     url: string,
     participantToken: string,
     participantMetadata: Metadata,

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -17,15 +17,27 @@ export type ConnectionConfig = {
   };
 };
 
+/**
+ *
+ * @param url fishjam Url
+ * @param participantToken
+ * @param participantMetadata
+ * @param config
+ */
 export async function joinRoom<
   ParticipantMetadata extends GenericMetadata = GenericMetadata,
 >(
   url: string,
-  peerToken: string,
-  peerMetadata: ParticipantMetadata,
+  participantToken: string,
+  participantMetadata: ParticipantMetadata,
   config: ConnectionConfig = {},
 ) {
-  await RNFishjamClientModule.connect(url, peerToken, peerMetadata, config);
+  await RNFishjamClientModule.connect(
+    url,
+    participantToken,
+    participantMetadata,
+    config,
+  );
 }
 
 export async function leaveRoom() {

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -32,7 +32,7 @@ export async function joinRoom<
   participantMetadata: ParticipantMetadata,
   config: ConnectionConfig = {},
 ) {
-  await RNFishjamClientModule.connect(
+  await RNFishjamClientModule.joinRoom(
     url,
     participantToken,
     participantMetadata,

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -17,7 +17,7 @@ export type ConnectionConfig = {
   };
 };
 
-export async function connect<
+export async function joinRoom<
   ParticipantMetadata extends GenericMetadata = GenericMetadata,
 >(
   url: string,

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -44,7 +44,7 @@ export {
   setTargetTrackEncoding,
 } from './common/webRTC';
 
-export { connect, leaveRoom } from './common/client';
+export { joinRoom, leaveRoom } from './common/client';
 
 export type { VideoPreviewViewProps } from './components/VideoPreviewView';
 export { VideoPreviewView } from './components/VideoPreviewView';


### PR DESCRIPTION
## Description

As we already have `leaveRoom` method, lets rename `connect` to `joinRoom` to keep naming parity.
Also rename peerTokne/peerMetadata to participantToken/participantMetadata.


## Motivation and Context

To make API more intuitive

## How has this been tested?

Please describe in detail how you tested your changes. Include details of your
testing environment, devices (ex. Iphone XYZ ios X.X.X & Samsung XYZ android
X.X.X)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
