### PR TITLE
[FCE-535]: Fix iOS preview when camera disabled

### DIFF
--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -236,9 +236,10 @@ class RNFishjamClient: FishjamClientListener {
         emitEvent(name: eventName, data: isCameraEnabledMap)
     }
 
-    func toggleCamera() throws {
+    func toggleCamera() throws -> Bool {
         try ensureVideoTrack()
         setCameraTrackState(getLocalVideoTrack()!, enabled: !isCameraOn)
+        return isCameraOn
     }
 
     func flipCamera() throws {
@@ -394,7 +395,7 @@ class RNFishjamClient: FishjamClientListener {
                         return [
                             "id": track.id,
                             "type": "Video",
-                            "metadata": track.metadata,
+                            "metadata": track.metadata.toDict(),
                             "encoding": track.encoding?.description,
                             "encodingReason": track.encodingReason?.rawValue,
                         ]
@@ -403,7 +404,7 @@ class RNFishjamClient: FishjamClientListener {
                         return [
                             "id": track.id,
                             "type": "Audio",
-                            "metadata": track.metadata,
+                            "metadata": track.metadata.toDict(),
                             "vadStatus": track.vadStatus.rawValue,
                         ]
 
@@ -411,21 +412,21 @@ class RNFishjamClient: FishjamClientListener {
                         return [
                             "id": track.id,
                             "type": "Video",
-                            "metadata": track.metadata,
+                            "metadata": track.metadata.toDict(),
                         ]
 
                     case let track as LocalScreencastTrack:
                         return [
                             "id": track.id,
                             "type": "Video",
-                            "metadata": track.metadata,
+                            "metadata": track.metadata.toDict(),
                         ]
 
                     case let track as LocalAudioTrack:
                         return [
                             "id": track.id,
                             "type": "Audio",
-                            "metadata": track.metadata,
+                            "metadata": track.metadata.toDict(),
                         ]
 
                     default:


### PR DESCRIPTION
## Description

- Local video track was not filtered out when camera was disabled, this was caused by wrong type passed from the native side `Metadata` (`AnyJson` under the hood) which is not supported.
- Added return value to `toggleCamera` to make it the same as on Android.

## Motivation and Context

- When camera was disabled, empty preview was still displayed on iOS.

## How has this been tested?

-  Successfully disabled camera on iOS and video preview was hiddem

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
