### PR TITLE
Disable back button and gesture only in room

### DIFF
--- a/examples/fishjam-chat/navigators/AppNavigator.tsx
+++ b/examples/fishjam-chat/navigators/AppNavigator.tsx
@@ -79,17 +79,21 @@ export default function AppNavigator() {
     <NavigationContainer>
       <Stack.Navigator
         initialRouteName="Home"
-        screenOptions={() => ({
-          headerBackTitleVisible: false,
-          headerBackVisible: false,
-        })}>
+        screenOptions={() => ({ headerBackTitleVisible: false })}>
         <Stack.Screen
           name="Home"
           options={{ headerShown: false }}
           component={TabNavigator}
         />
         <Stack.Screen name="Preview" component={PreviewScreen} />
-        <Stack.Screen name="Room" component={RoomScreen} />
+        <Stack.Screen
+          name="Room"
+          options={{
+            headerBackVisible: false,
+            gestureEnabled: false,
+          }}
+          component={RoomScreen}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -3,6 +3,7 @@ import {
   useMicrophone,
   joinRoom,
   VideoPreviewView,
+  leaveRoom,
 } from '@fishjam-cloud/react-native-client';
 import BottomSheet from '@gorhom/bottom-sheet';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
@@ -41,6 +42,8 @@ type BottomSheetRef = Props & {
 
 const { JOIN_BUTTON, TOGGLE_MICROPHONE_BUTTON } = previewScreenLabels;
 
+let unsubscribeBeforeRemove: () => void;
+
 function PreviewScreen({
   navigation,
   route,
@@ -72,7 +75,11 @@ function PreviewScreen({
       quality: 'HD169',
       cameraEnabled: true,
     });
-  }, [prepareCamera]);
+
+    unsubscribeBeforeRemove = navigation.addListener('beforeRemove', () => {
+      leaveRoom();
+    });
+  }, [prepareCamera, navigation]);
 
   const onJoinPressed = async () => {
     await joinRoom<ParticipantMetadata>(
@@ -82,6 +89,9 @@ function PreviewScreen({
         name: route.params.userName,
       },
     );
+
+    unsubscribeBeforeRemove();
+
     navigation.navigate('Room', {
       isCameraOn,
       userName: route?.params?.userName,


### PR DESCRIPTION
## Description

Enable back button for preview screen and disable back gesture for room screen in `fishjam-chat`.

## Motivation and Context

If I make a mistake in credentials for joining room I would like to be able to close the screen and fix it. Currently only the back gesture wasn't disabled and could be used to go back.

Additionally, I could use the gesture to go back from the room screen instead of having to tap end call button.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.