### PR TITLE
Add defaults to expo plugin

### DIFF
--- a/packages/react-native-client/plugin/src/types.ts
+++ b/packages/react-native-client/plugin/src/types.ts
@@ -1,9 +1,9 @@
 export type FishjamPluginOptions = {
-  android: {
-    enableForegroundService: boolean;
+  android?: {
+    enableForegroundService?: boolean;
   };
-  ios: {
+  ios?: {
     iphoneDeploymentTarget?: string;
-    enableScreensharing: boolean;
+    enableScreensharing?: boolean;
   };
 };

--- a/packages/react-native-client/plugin/src/types.ts
+++ b/packages/react-native-client/plugin/src/types.ts
@@ -1,9 +1,11 @@
-export type FishjamPluginOptions = {
-  android?: {
-    enableForegroundService?: boolean;
-  };
-  ios?: {
-    iphoneDeploymentTarget?: string;
-    enableScreensharing?: boolean;
-  };
-};
+export type FishjamPluginOptions =
+  | {
+      android?: {
+        enableForegroundService?: boolean;
+      };
+      ios?: {
+        iphoneDeploymentTarget?: string;
+        enableScreensharing?: boolean;
+      };
+    }
+  | undefined;

--- a/packages/react-native-client/plugin/src/withFishjamAndroid.ts
+++ b/packages/react-native-client/plugin/src/withFishjamAndroid.ts
@@ -32,7 +32,7 @@ export const withFishjamAndroid: ConfigPlugin<FishjamPluginOptions> = (
   config,
   props,
 ) => {
-  if (props.android?.enableForegroundService) {
+  if (props?.android?.enableForegroundService) {
     config = withFishjamForegroundService(config);
   }
   return config;

--- a/packages/react-native-client/plugin/src/withFishjamAndroid.ts
+++ b/packages/react-native-client/plugin/src/withFishjamAndroid.ts
@@ -30,9 +30,9 @@ const withFishjamForegroundService: ConfigPlugin = (config) => {
 
 export const withFishjamAndroid: ConfigPlugin<FishjamPluginOptions> = (
   config,
-  { android: { enableForegroundService } },
+  props,
 ) => {
-  if (enableForegroundService) {
+  if (props.android?.enableForegroundService) {
     config = withFishjamForegroundService(config);
   }
   return config;

--- a/packages/react-native-client/plugin/src/withFishjamIos.ts
+++ b/packages/react-native-client/plugin/src/withFishjamIos.ts
@@ -244,7 +244,7 @@ const withFishjamSBE: ConfigPlugin<FishjamPluginOptions> = (
         ) {
           const buildSettingsObj = configurations[key].buildSettings;
           buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
-            options.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
+            options?.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
           buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
           buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${SBE_TARGET_NAME}/${SBE_TARGET_NAME}.entitlements`;
           buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
@@ -268,14 +268,14 @@ const withFishjamSBE: ConfigPlugin<FishjamPluginOptions> = (
  * Allows for dynamically changing deploymentTarget.
  */
 const withFishjamIos: ConfigPlugin<FishjamPluginOptions> = (config, props) => {
-  if (props.ios?.enableScreensharing) {
+  if (props?.ios?.enableScreensharing) {
     withAppGroupPermissions(config);
     withInfoPlistConstants(config);
     withFishjamSBE(config, props);
   }
   withPodfileProperties(config, (config) => {
     config.modResults['ios.deploymentTarget'] =
-      props.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
+      props?.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
     return config;
   });
   return config;

--- a/packages/react-native-client/plugin/src/withFishjamIos.ts
+++ b/packages/react-native-client/plugin/src/withFishjamIos.ts
@@ -244,7 +244,7 @@ const withFishjamSBE: ConfigPlugin<FishjamPluginOptions> = (
         ) {
           const buildSettingsObj = configurations[key].buildSettings;
           buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
-            options.ios.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
+            options.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
           buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
           buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${SBE_TARGET_NAME}/${SBE_TARGET_NAME}.entitlements`;
           buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
@@ -268,14 +268,14 @@ const withFishjamSBE: ConfigPlugin<FishjamPluginOptions> = (
  * Allows for dynamically changing deploymentTarget.
  */
 const withFishjamIos: ConfigPlugin<FishjamPluginOptions> = (config, props) => {
-  if (props.ios.enableScreensharing) {
+  if (props.ios?.enableScreensharing) {
     withAppGroupPermissions(config);
     withInfoPlistConstants(config);
     withFishjamSBE(config, props);
   }
   withPodfileProperties(config, (config) => {
     config.modResults['ios.deploymentTarget'] =
-      props.ios.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
+      props.ios?.iphoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
     return config;
   });
   return config;


### PR DESCRIPTION
## Description

Allow expo plugin to be used without any params.

## Motivation and Context

When plugin is used with empty configuration, it crashes prebuild step

