### PR TITLE
Make participant metadata optional in joinRoom

### DIFF
--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -29,14 +29,14 @@ export async function joinRoom<
 >(
   url: string,
   participantToken: string,
-  participantMetadata: ParticipantMetadata,
-  config: ConnectionConfig = {},
+  participantMetadata?: ParticipantMetadata,
+  config?: ConnectionConfig,
 ) {
   await RNFishjamClientModule.joinRoom(
     url,
     participantToken,
-    participantMetadata,
-    config,
+    participantMetadata ?? {},
+    config ?? {},
   );
 }
 /**

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -19,9 +19,9 @@ export type ConnectionConfig = {
 
 /**
  * @param url fishjam Url
- * @param participantToken
- * @param participantMetadata
- * @param config
+ * @param participantToken token received from server (or Room Manager)
+ * @param participantMetadata string indexed record with metadata, that will be available to all other participants
+ * @param config additional connection configuration
  * @category Connection
  */
 export async function joinRoom<

--- a/packages/react-native-client/src/common/metadata.ts
+++ b/packages/react-native-client/src/common/metadata.ts
@@ -2,12 +2,12 @@ import { GenericMetadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 
 /**
- * a function that updates endpoints's metadata on the server
- * @param metadata a map indexed by strings, containing participants metadata to be sent to the server
+ * Updates metadata send to other participants
+ * @param participantMetadata string indexed record with metadata, that will be available to all other participants
  * @category Connection
  */
 export async function updatePeerMetadata<
   ParticipantMetadata extends GenericMetadata = GenericMetadata,
->(metadata: ParticipantMetadata) {
-  await RNFishjamClientModule.updatePeerMetadata(metadata);
+>(participantMetadata: ParticipantMetadata) {
+  await RNFishjamClientModule.updatePeerMetadata(participantMetadata);
 }

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -48,6 +48,7 @@ export {
   setTargetTrackEncoding,
 } from './common/webRTC';
 
+export type { ConnectionConfig } from './common/client';
 export { joinRoom, leaveRoom } from './common/client';
 
 export type { VideoPreviewViewProps } from './components/VideoPreviewView';


### PR DESCRIPTION
## Description

Make participant metadata optional in joinRoom

There are also few small changes to docs


## Motivation and Context

As we could pass metadata form server SDK now, we can make this param optional. It should not be required.

## How has this been tested?

Please describe in detail how you tested your changes. Include details of your
testing environment, devices (ex. Iphone XYZ ios X.X.X & Samsung XYZ android
X.X.X)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
