### PR TITLE
[FCE-366] Update deprecated artefact-action in workflows

### DIFF
--- a/.github/workflows/react_native_e2e_android.yaml
+++ b/.github/workflows/react_native_e2e_android.yaml
@@ -87,11 +87,10 @@ jobs:
           cd $GITHUB_WORKSPACE
           yarn install --frozen-lockfile
       - name: Upload yarn.lock artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: yarn-lock
-          path: |
-            /home/runner/work/mobile-client-sdk/mobile-client-sdk/yarn.lock
+          path: /home/runner/work/mobile-client-sdk/mobile-client-sdk/yarn.lock
       - name: Run yarn build
         run: |
           cd $GITHUB_WORKSPACE


### PR DESCRIPTION
## Description

- Bumped to new action version 

## Motivation and Context

- The previous version will be deprecated by 30.11.2024

## How has this been tested?

I didn't test it as this action is disabled right now, however, other actions already use the same syntax so there should be no problems.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.