### PR TITLE
Change minSdkVersion to 21

### DIFF
--- a/examples/fishjam-chat/app.json
+++ b/examples/fishjam-chat/app.json
@@ -38,7 +38,6 @@
         "expo-build-properties",
         {
           "android": {
-            "minSdkVersion": 24,
             "compileSdkVersion": 34,
             "targetSdkVersion": 34
           }

--- a/examples/fishjam-chat/app.json
+++ b/examples/fishjam-chat/app.json
@@ -35,15 +35,6 @@
     "androidStatusBar": { "hidden": true },
     "plugins": [
       [
-        "expo-build-properties",
-        {
-          "android": {
-            "compileSdkVersion": 34,
-            "targetSdkVersion": 34
-          }
-        }
-      ],
-      [
         "@fishjam-cloud/react-native-client",
         {
           "android": {

--- a/examples/fishjam-chat/package.json
+++ b/examples/fishjam-chat/package.json
@@ -19,7 +19,6 @@
     "@react-navigation/native": "^6.1.18",
     "@react-navigation/native-stack": "^6.11.0",
     "expo": "^51.0.32",
-    "expo-build-properties": "~0.12.5",
     "expo-camera": "^15.0.15",
     "expo-device": "^6.0.2",
     "expo-status-bar": "~1.12.1",

--- a/packages/android-client/FishjamClient/build.gradle
+++ b/packages/android-client/FishjamClient/build.gradle
@@ -14,11 +14,11 @@ ext {
 
 android {
     namespace 'com.fishjamcloud.client'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
-        minSdk 24
-        targetSdk 33
+        minSdk 21
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/packages/react-native-client/android/build.gradle
+++ b/packages/react-native-client/android/build.gradle
@@ -55,11 +55,11 @@ afterEvaluate {
 
 android {
   namespace = "io.fishjam.reactnative"
-  compileSdk(31)
+  compileSdk(34)
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
     versionCode 1
     versionName "${packageVersion}"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,7 +2440,6 @@ __metadata:
     "@react-navigation/native-stack": "npm:^6.11.0"
     "@types/react": "npm:^18.3.7"
     expo: "npm:^51.0.32"
-    expo-build-properties: "npm:~0.12.5"
     expo-camera: "npm:^15.0.15"
     expo-device: "npm:^6.0.2"
     expo-status-bar: "npm:~1.12.1"
@@ -5539,18 +5538,6 @@ __metadata:
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
   checksum: 10c0/41e23642cbe545889245b9d2a45854ebba51cda6c778ebced9649420d9205f2efb39cb43dbc41e358409223b1ea43303ae4839db682c848b891e4811da1a5a71
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.11.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/ec3ba10a573c6b60f94639ffc53526275917a2df6810e4ab5a6b959d87459f9ef3f00d5e7865b82677cb7d21590355b34da14d1d0b9c32d75f95a187e76fff35
   languageName: node
   linkType: hard
 
@@ -8930,18 +8917,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-build-properties@npm:~0.12.5":
-  version: 0.12.5
-  resolution: "expo-build-properties@npm:0.12.5"
-  dependencies:
-    ajv: "npm:^8.11.0"
-    semver: "npm:^7.6.0"
-  peerDependencies:
-    expo: "*"
-  checksum: 10c0/1418c94d97cc5c5ecb5ec947ca7eb218bb3d14a5c7127c6acaf9f763af5060df6e581e90b7ec210cdf4fb16d676f58500414127375b2e169646c66b5bd79e9cc
-  languageName: node
-  linkType: hard
-
 "expo-camera@npm:^15.0.15":
   version: 15.0.15
   resolution: "expo-camera@npm:15.0.15"
@@ -9218,13 +9193,6 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
-  languageName: node
-  linkType: hard
-
-"fast-uri@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "fast-uri@npm:3.0.1"
-  checksum: 10c0/3cd46d6006083b14ca61ffe9a05b8eef75ef87e9574b6f68f2e17ecf4daa7aaadeff44e3f0f7a0ef4e0f7e7c20fc07beec49ff14dc72d0b500f00386592f2d10
   languageName: node
   linkType: hard
 
@@ -11953,13 +11921,6 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 10c0/108fa90d4cc6f08243aedc6da16c408daf81793bf903e9fd5ab21983cda433d5d2da49e40711da016289465ec2e62e0324dcdfbc06275a607fe3233fde4942ce
-  languageName: node
-  linkType: hard
-
-"json-schema-traverse@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "json-schema-traverse@npm:1.0.0"
-  checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Downgraded `minSdkVersion` to 21
- Upgraded `targetSdk` and `compileSdk` to 34
- Removed `expo-build-properties` from the example because it's not needed anymore

## Motivation and Context

We required our SDKs users to have minSdkVersion of at least 24, which didn't work out of the box for a new expo app. 

## How has this been tested?

- Build and run Android after repo clean

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
