### PR TITLE
[FCE-578] Update metadata and fix iOS metadata handling

### DIFF
--- a/examples/fishjam-chat/components/VideosGrid.tsx
+++ b/examples/fishjam-chat/components/VideosGrid.tsx
@@ -30,7 +30,7 @@ export function parsePeersToTracks(peers: Peer<PeerMetadata>[]): GridTrack[] {
         .map((track) => ({
           ...track,
           isLocal: peer.isLocal,
-          userName: peer.metadata?.name,
+          userName: peer.metadata?.displayName,
         }))
         .filter((track) => track.type === 'Video' && track.isActive),
     );

--- a/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -52,12 +52,12 @@ async function getFishjamServer(
   }
   const tokenData = (await response.json()) as {
     url: string;
-    participantToken: string;
+    peerToken: string;
   };
 
   return {
     fishjamUrl: tokenData.url,
-    token: tokenData.participantToken,
+    token: tokenData.peerToken,
   };
 }
 

--- a/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
+++ b/examples/fishjam-chat/screens/ConnectWithRoomManagerScreen.tsx
@@ -52,12 +52,12 @@ async function getFishjamServer(
   }
   const tokenData = (await response.json()) as {
     url: string;
-    token: string;
+    participantToken: string;
   };
 
   return {
     fishjamUrl: tokenData.url,
-    token: tokenData.token,
+    token: tokenData.participantToken,
   };
 }
 

--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -86,7 +86,7 @@ function PreviewScreen({
       route.params.fishjamUrl,
       route.params.peerToken,
       {
-        name: route.params.userName,
+        displayName: route.params.userName,
       },
     );
 

--- a/examples/fishjam-chat/types/metadata.ts
+++ b/examples/fishjam-chat/types/metadata.ts
@@ -1,1 +1,1 @@
-export type PeerMetadata = { name?: string };
+export type PeerMetadata = { displayName?: string };

--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -78,17 +78,6 @@ public class FishjamClient {
     }
 
     /**
-    * Tries to join the room. If user is accepted then {@link FishjamClient.onJoinSuccess} will be called.
-    * In other case {@link FishjamClient.onJoinError} is invoked.
-    *
-    * @param peerMetadata - Any information that other peers will receive in onPeerJoined
-    * after accepting this peer
-    */
-    public func join(peerMetadata: Metadata = Metadata()) {
-        client.join(peerMetadata: peerMetadata)
-    }
-
-    /**
     * Creates a video track utilizing device's camera.
     *
     * The client assumes that the user has already granted camera permissions.

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -84,7 +84,7 @@ internal class FishjamClientInternal: WebSocketDelegate, PeerConnectionListener,
         commandsQueue.addCommand(
             Command(commandName: .JOIN, clientStateAfterCommand: .JOINED) {
                 self.localEndpoint = self.localEndpoint.copyWith(metadata: self.config?.peerMetadata)
-                self.rtcEngineCommunication.connect(metadata: self.config?.peerMetadata ?? Metadata())
+                self.rtcEngineCommunication.connect(metadata: self.localEndpoint.metadata)
             })
     }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -80,11 +80,11 @@ internal class FishjamClientInternal: WebSocketDelegate, PeerConnectionListener,
         )
     }
 
-    func join(peerMetadata: Metadata = Metadata()) {
+    func join() {
         commandsQueue.addCommand(
             Command(commandName: .JOIN, clientStateAfterCommand: .JOINED) {
-                self.localEndpoint = self.localEndpoint.copyWith(metadata: peerMetadata)
-                self.rtcEngineCommunication.connect(metadata: peerMetadata)
+                self.localEndpoint = self.localEndpoint.copyWith(metadata: self.config?.peerMetadata)
+                self.rtcEngineCommunication.connect(metadata: self.config?.peerMetadata ?? Metadata())
             })
     }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -175,10 +175,6 @@ class RNFishjamClient: FishjamClientListener {
         connectPromise = nil
     }
 
-    func onAuthSuccess() {
-        join()
-    }
-
     func joinRoom(
         url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig,
         promise: Promise
@@ -196,10 +192,6 @@ class RNFishjamClient: FishjamClientListener {
                 reconnectConfig: reconnectConfig
             ))
 
-    }
-
-    func join() {
-        RNFishjamClient.fishjamClient?.join(peerMetadata: localUserMetadata)
     }
 
     func leaveRoom() {
@@ -402,11 +394,11 @@ class RNFishjamClient: FishjamClientListener {
     func getPeers() throws -> [[String: Any?]] {
         let endpoints = RNFishjamClient.getLocalAndRemoteEndpoints()
         return endpoints.compactMap { endpoint in
-            [
+            return [
                 "id": endpoint.id,
                 "isLocal": endpoint.id == RNFishjamClient.fishjamClient!.getLocalEndpoint().id,
                 "type": endpoint.type,
-                "metadata": endpoint.metadata,
+                "metadata": endpoint.metadata.toDict(),
                 "tracks": endpoint.tracks.values.compactMap { track -> [String: Any?]? in
                     switch track {
                     case let track as RemoteVideoTrack:

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -394,7 +394,7 @@ class RNFishjamClient: FishjamClientListener {
     func getPeers() throws -> [[String: Any?]] {
         let endpoints = RNFishjamClient.getLocalAndRemoteEndpoints()
         return endpoints.compactMap { endpoint in
-            return [
+            [
                 "id": endpoint.id,
                 "isLocal": endpoint.id == RNFishjamClient.fishjamClient!.getLocalEndpoint().id,
                 "type": endpoint.type,


### PR DESCRIPTION
## Description

Updated metadata to match Fishjam and removed `join` method on iOS SDK to match Android while also passing correct peer metadata instead of empty one.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
