### PR TITLE
[FCE-670]: Fix events emitted from wrong thread

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -744,7 +744,9 @@ class RNFishjamClient(
     event: EmitableEvents,
     data: Map<String, Any?> = mapOf()
   ) {
-    sendEvent(event.name, data)
+    CoroutineScope(Dispatchers.Main).launch {
+      sendEvent(event.name, data)
+    }
   }
 
   fun emitWarning(warning: String) {

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -683,7 +683,9 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func emit(event: EmitableEvents, data: [String: Any] = [:]) {
-        sendEvent(event.name, data)
+        DispatchQueue.main.async { [weak self] in
+            self?.sendEvent(event.name, data)
+        }
     }
 
     func emit(warning: String) {


### PR DESCRIPTION
## Description

- Synchronized event emitting on Android and iOS

## Motivation and Context

Events could sometimes be emitted from wrong thread (for example when value was changed from a different thread than main). 

## How has this been tested?

- Tested event emitting on Android and iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
