### PR TITLE
[FCE-667] Remove protocol conformances resulting in warnings

### DIFF
--- a/packages/ios-client/Sources/FishjamClient/CommandsQueue.swift
+++ b/packages/ios-client/Sources/FishjamClient/CommandsQueue.swift
@@ -1,5 +1,13 @@
 import Promises
 
+class CommandQueueError: Error {
+    let message: String
+
+    init(message: String) {
+        self.message = message
+    }
+}
+
 internal class CommandsQueue {
     var clientState: ClientState = ClientState.CREATED
     private var commandsQueue: [Command] = []
@@ -40,7 +48,7 @@ internal class CommandsQueue {
     func clear() {
         clientState = .CREATED
         commandsQueue.forEach { command in
-            command.promise.reject("Command queue was cleared")
+            command.promise.reject(CommandQueueError(message: "Command queue was cleared"))
         }
         commandsQueue.removeAll()
     }

--- a/packages/ios-client/Sources/FishjamClient/CommandsQueue.swift
+++ b/packages/ios-client/Sources/FishjamClient/CommandsQueue.swift
@@ -3,7 +3,7 @@ import Promises
 class CommandQueueError: Error {
     let message: String
 
-    init(message: String) {
+    init(_ message: String) {
         self.message = message
     }
 }
@@ -48,7 +48,7 @@ internal class CommandsQueue {
     func clear() {
         clientState = .CREATED
         commandsQueue.forEach { command in
-            command.promise.reject(CommandQueueError(message: "Command queue was cleared"))
+            command.promise.reject(CommandQueueError("Command queue was cleared"))
         }
         commandsQueue.removeAll()
     }

--- a/packages/ios-client/Sources/FishjamClient/media/Capturers/CameraCapturer.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Capturers/CameraCapturer.swift
@@ -72,7 +72,7 @@ class CameraCapturer: VideoCapturer {
             if diff < currentDiff {
                 selectedFormat = format
                 currentDiff = diff
-                selectedDimension = dimension
+                selectedDimension = Dimensions(dimension)
             }
         }
 

--- a/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
@@ -18,7 +18,7 @@ public struct Dimensions {
         self.dimensions = dimensions
     }
 
-    /// Swaps height with width.
+    /// Returns new struct with swapped height and width.
     public var flipped: Dimensions {
         Dimensions(width: height, height: width)
     }

--- a/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
@@ -9,12 +9,6 @@ extension Dimensions {
     public static let aspect4By3 = 4.0 / 3.0
 }
 
-extension Dimensions: Equatable {
-    public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
-        lhs.width == rhs.width && lhs.height == rhs.height
-    }
-}
-
 extension Dimensions {
     /// Swaps height with width.
     public func flip() -> Dimensions {

--- a/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Dimensions.swift
@@ -1,17 +1,31 @@
 import CoreMedia
 import Foundation
 
-/// Type refering to video dimensions.
-public typealias Dimensions = CMVideoDimensions
-
-extension Dimensions {
+public struct Dimensions {
     public static let aspect16By9 = 16.0 / 9.0
     public static let aspect4By3 = 4.0 / 3.0
+
+    private var dimensions: CMVideoDimensions
+
+    public var width: Int32 { dimensions.width }
+    public var height: Int32 { dimensions.height }
+
+    public init(width: Int32, height: Int32) {
+        self.dimensions = CMVideoDimensions(width: width, height: height)
+    }
+
+    public init(_ dimensions: CMVideoDimensions) {
+        self.dimensions = dimensions
+    }
+
+    /// Swaps height with width.
+    public var flipped: Dimensions {
+        Dimensions(width: height, height: width)
+    }
 }
 
-extension Dimensions {
-    /// Swaps height with width.
-    public func flip() -> Dimensions {
-        return Dimensions(width: height, height: width)
+extension Dimensions: Equatable {
+    public static func == (lhs: Dimensions, rhs: Dimensions) -> Bool {
+        lhs.width == rhs.width && lhs.height == rhs.height
     }
 }

--- a/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
+++ b/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
@@ -35,7 +35,7 @@ public class VideoView: UIView {
     /// or when the resolution changes adaptively.
     public private(set) var dimensions: Dimensions? {
         didSet {
-            guard oldValue?.width != dimensions?.width || oldValue?.height != dimensions?.height else { return }
+            guard oldValue != dimensions else { return }
 
             // when the dimensions change force the new layout
             shouldLayout()

--- a/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
+++ b/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
@@ -35,7 +35,7 @@ public class VideoView: UIView {
     /// or when the resolution changes adaptively.
     public private(set) var dimensions: Dimensions? {
         didSet {
-            guard oldValue != dimensions else { return }
+            guard oldValue?.width != dimensions?.width || oldValue?.height != dimensions?.height else { return }
 
             // when the dimensions change force the new layout
             shouldLayout()

--- a/packages/ios-client/Sources/FishjamClient/utils/String+Error.swift
+++ b/packages/ios-client/Sources/FishjamClient/utils/String+Error.swift
@@ -1,1 +1,0 @@
-extension String: Error {}

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -112,7 +112,7 @@ class RNFishjamClient: FishjamClientListener {
             }
         }()
         let videoParameters = VideoParameters(
-            dimensions: flipDimensions ? preset.dimensions.flip() : preset.dimensions,
+            dimensions: flipDimensions ? preset.dimensions.flipped : preset.dimensions,
             maxBandwidth: videoBandwidthLimit,
             simulcastConfig: simulcastConfig
         )
@@ -752,7 +752,7 @@ class RNFishjamClient: FishjamClientListener {
             preset = VideoParameters.presetScreenShareHD15
         }
         return VideoParameters(
-            dimensions: preset.dimensions.flip(),
+            dimensions: preset.dimensions.flipped,
             maxBandwidth: screenShareMaxBandwidth,
             maxFps: preset.maxFps,
             simulcastConfig: screenShareSimulcastConfig


### PR DESCRIPTION
## Description

Remove protocol conformances resulting in `extension declares a conformance of imported type '[...]' to imported protocol '[...]'; this will not behave correctly if the owners of '[...]' introduce this conformance in the future` warnings

## Motivation and Context

We should avoid adding such protocol conformances since it may result in issues in the future. ~~And because because `Dimensions` is only compared once then it seems better to just do the comparison in place.~~
`Dimensions` would work better as a wrapper of `CMVideoDimensions`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
