### PR TITLE
[FCE-712]: Fix ios preview

### DIFF
--- a/FishjamCloudClient.podspec
+++ b/FishjamCloudClient.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 
-  s.dependency 'WebRTC-SDK', '=125.6422.05'
+  s.dependency 'WebRTC-SDK', '=125.6422.03'
   s.dependency 'SwiftProtobuf', '~> 1.18.0'
   s.dependency 'Starscream', '~> 4.0.0'
   s.dependency 'PromisesSwift'

--- a/packages/android-client/FishjamClient/build.gradle
+++ b/packages/android-client/FishjamClient/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'androidx.core:core:1.8.20'
 
-    api 'io.github.webrtc-sdk:android:125.6422.05'
+    api 'io.github.webrtc-sdk:android:125.6422.03'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation "io.mockk:mockk:1.13.2"


### PR DESCRIPTION
## Description

- Looks like WebRTC SDK upgrade disabled video preview on iOS

## Motivation and Context

- Video preview doesn't work on iOS

## How has this been tested?

- Run iOS app without SDK upgrade

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
