### PR TITLE
FCE-724: Fix mobile screensharing doesn't work with video room

### DIFF
--- a/packages/react-native-client/src/hooks/useAppScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useAppScreenShare.ts
@@ -43,7 +43,7 @@ function useIosAppScreenShare(): AppScreenShareData {
         ...screenShareOptions,
         screenShareMetadata: {
           displayName: 'presenting',
-          type: 'screensharing' as const,
+          type: 'screenShareVideo' as const,
           active: !isAppScreenShareOn,
         },
       };

--- a/packages/react-native-client/src/hooks/useScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useScreenShare.ts
@@ -102,7 +102,7 @@ export function useScreenShare() {
         ...screenShareOptions,
         screenShareMetadata: {
           displayName: 'presenting',
-          type: 'screensharing' as const,
+          type: 'screenShareVideo' as const,
           active: !isScreenShareOn,
         },
       };

--- a/packages/react-native-client/src/types.ts
+++ b/packages/react-native-client/src/types.ts
@@ -44,7 +44,7 @@ export type TrackBandwidthLimit = BandwidthLimit | SimulcastBandwidthLimit;
 
 export type TrackMetadata = {
   active: boolean;
-  type: 'audio' | 'camera' | 'screensharing';
+  type: 'audio' | 'camera' | 'screenShareVideo';
 };
 
 export type GenericMetadata = Record<string, unknown>;


### PR DESCRIPTION
## Description

- `peerMatadata` was different between mobile and web.

## Motivation and Context

- Screen sharing was not displayed in video room

## How has this been tested?

Please describe in detail how you tested your changes. Include details of your
testing environment, devices (ex. Iphone XYZ ios X.X.X & Samsung XYZ android
X.X.X)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.