### PR TITLE
[FCE-804] Add branded IDs for peers and tracks

### DIFF
--- a/examples/fishjam-chat/components/VideosGrid.tsx
+++ b/examples/fishjam-chat/components/VideosGrid.tsx
@@ -13,6 +13,7 @@ import { BrandColors } from '../utils/Colors';
 import Typo from './Typo';
 import { PeerMetadata } from '../types/metadata';
 import VADIcon from './VADIcon';
+import { PeerId } from '@fishjam-cloud/react-native-client';
 
 type Props = {
   videoTracks: GridTrack[];
@@ -20,7 +21,7 @@ type Props = {
 };
 
 type GridTrack = Track & {
-  peerId: string;
+  peerId: PeerId;
   isLocal: boolean;
   userName: string | undefined;
 };

--- a/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionManager.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionManager.swift
@@ -23,7 +23,6 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
     private var config: RTCConfiguration?
 
     private var midToTrackId: [String: String] = [:]
-    
 
     private static let mediaConstraints = RTCMediaConstraints(
         mandatoryConstraints: nil, optionalConstraints: ["DtlsSrtpKeyAgreement": kRTCMediaConstraintsValueTrue])
@@ -238,7 +237,7 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
             "stun:stun.l.google.com:19302",
             "stun:stun.l.google.com:5349",
         ]
-        
+
         return RTCIceServer(urlStrings: iceUrls)
     }
 
@@ -398,7 +397,7 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
         guard let pc = connection else {
             return
         }
-        
+
         if needsRestart && !isExWebrtc {
             pc.restartIce()
         }

--- a/packages/react-native-client/src/common/webRTC.ts
+++ b/packages/react-native-client/src/common/webRTC.ts
@@ -1,5 +1,6 @@
 import { TrackEncoding } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
+import type { TrackId } from '../hooks/usePeers';
 
 /**
  * sets track encoding that server should send to the client library.
@@ -12,7 +13,7 @@ import RNFishjamClientModule from '../RNFishjamClientModule';
  * @category Debugging
  */
 export async function setTargetTrackEncoding(
-  trackId: string,
+  trackId: TrackId,
   encoding: TrackEncoding,
 ) {
   await RNFishjamClientModule.setTargetTrackEncoding(trackId, encoding);

--- a/packages/react-native-client/src/components/VideoRendererView.tsx
+++ b/packages/react-native-client/src/components/VideoRendererView.tsx
@@ -3,12 +3,13 @@ import * as React from 'react';
 import { ViewStyle } from 'react-native';
 
 import { VideoLayout } from '../types';
+import type { TrackId } from '../hooks/usePeers';
 
 export type VideoRendererProps = {
   /**
    * id of the video track which you want to render.
    */
-  trackId: string;
+  trackId: TrackId;
   /**
    * Video layout inside of the component
    * @default `FILL`

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { GenericMetadata, TrackEncoding, TrackMetadata } from '../types';
+import { Brand, GenericMetadata, TrackEncoding, TrackMetadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+
+export type PeerId = Brand<string, 'PeerId'>;
+export type TrackId = Brand<string, 'TrackId'>;
 
 export type TrackType = 'Audio' | 'Video';
 
@@ -20,7 +23,7 @@ export type PeerTrackMetadata<PeerMetadata, ServerMetadata> = {
 };
 
 type TrackBase = {
-  id: string;
+  id: TrackId;
   type: TrackType;
   isActive: boolean;
 };
@@ -55,7 +58,7 @@ export type Peer<
   /**
    *  id used to identify a peer
    */
-  id: string;
+  id: PeerId;
   /**
    * whether the peer is local or remote
    */

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -2,7 +2,9 @@ import { initializeWarningListener } from './utils/errorListener';
 
 export type {
   Peer,
+  PeerId,
   Track,
+  TrackId,
   TrackType,
   VadStatus,
   EncodingReason,


### PR DESCRIPTION
## Description

Instead of strings, our IDs can be defined as branded types. This way it won't be possible* to use Track ID instead of Peer ID in typescript code

*ok, it would be possible if someone does not care about proper TS

## Motivation and Context

This change should make our API less error prone

## How has this been tested?

App is still passing CI checks

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
