### PR TITLE
[FCE-821] Make useMicrophone stateless

### DIFF
--- a/packages/react-native-client/src/hooks/useMicrophone.ts
+++ b/packages/react-native-client/src/hooks/useMicrophone.ts
@@ -1,7 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import RNFishjamClientModule from '../RNFishjamClientModule';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
+import { useFishjamEventState } from './useFishjamEventState';
 
 /**
  * This hook can toggle microphone on/off and provides current microphone state.
@@ -9,15 +10,13 @@ import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
  * @group Hooks
  */
 export function useMicrophone() {
-  const [isMicrophoneOn, setIsMicrophoneOn] = useState<boolean>(
+  const isMicrophoneOn = useFishjamEventState<boolean>(
+    ReceivableEvents.IsMicrophoneOn,
     RNFishjamClientModule.isMicrophoneOn,
   );
 
-  useFishjamEvent(ReceivableEvents.IsMicrophoneOn, setIsMicrophoneOn);
-
   const toggleMicrophone = useCallback(async () => {
-    const status = await RNFishjamClientModule.toggleMicrophone();
-    setIsMicrophoneOn(status);
+    await RNFishjamClientModule.toggleMicrophone();
   }, []);
 
   return {


### PR DESCRIPTION
## Description

Refactored `useMicrophone` code to use `useFishjamEventState` instead of `useState` and `useFishjamEvent`.

## Motivation and Context

The code will be simpler and less error-prone. It should fix FCE-809 as well.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
