### PR TITLE
[FCE-846] Make additional hooks stateless

### DIFF
--- a/packages/react-native-client/src/hooks/useAppScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useAppScreenShare.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 import { SimulcastConfig } from '../types';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
 import { ScreenShareOptions } from './useScreenShare';
 import { Platform } from 'react-native';
+import { useFishjamEventState } from './useFishjamEventState';
 
 const defaultSimulcastConfig = () => ({
   enabled: false,
@@ -27,15 +28,15 @@ type AppScreenShareData = {
  * @group Hooks
  */
 function useIosAppScreenShare(): AppScreenShareData {
-  const [isAppScreenShareOn, setIsAppScreenShareOn] = useState(
+  const isAppScreenShareOn = useFishjamEventState<boolean>(
+    ReceivableEvents.IsAppScreenShareOn,
     RNFishjamClientModule.isAppScreenShareOn,
   );
 
-  const [simulcastConfig, setSimulcastConfig] = useState<SimulcastConfig>(
+  const simulcastConfig = useFishjamEventState<SimulcastConfig>(
+    ReceivableEvents.SimulcastConfigUpdate,
     screenShareSimulcastConfig,
   );
-
-  useFishjamEvent(ReceivableEvents.IsAppScreenShareOn, setIsAppScreenShareOn);
 
   const toggleAppScreenShare = useCallback(
     async (screenShareOptions: Partial<ScreenShareOptions> = {}) => {
@@ -49,7 +50,6 @@ function useIosAppScreenShare(): AppScreenShareData {
       };
       await RNFishjamClientModule.toggleAppScreenShare(options);
       screenShareSimulcastConfig = defaultSimulcastConfig(); //to do: sync with camera settings
-      setSimulcastConfig(screenShareSimulcastConfig);
     },
     [isAppScreenShareOn],
   );

--- a/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
+++ b/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
@@ -1,6 +1,5 @@
-import { useState } from 'react';
-
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
+import { useFishjamEventState } from './useFishjamEventState';
 
 /**
  * This hook provides current bandwidth estimation
@@ -10,9 +9,6 @@ import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
  * @group Hooks
  */
 export function useBandwidthEstimation() {
-  const [estimation, setEstimation] = useState<number | null>(null);
-
-  useFishjamEvent(ReceivableEvents.BandwidthEstimation, setEstimation);
-
+  const estimation = useFishjamEventState<number | null>(ReceivableEvents.BandwidthEstimation, null);
   return { estimation };
 }

--- a/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
+++ b/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
@@ -9,6 +9,9 @@ import { useFishjamEventState } from './useFishjamEventState';
  * @group Hooks
  */
 export function useBandwidthEstimation() {
-  const estimation = useFishjamEventState<number | null>(ReceivableEvents.BandwidthEstimation, null);
+  const estimation = useFishjamEventState<number | null>(
+    ReceivableEvents.BandwidthEstimation,
+    null,
+  );
   return { estimation };
 }

--- a/packages/react-native-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-native-client/src/hooks/usePeerStatus.ts
@@ -1,6 +1,6 @@
-import { useCallback, useState } from 'react';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
 import RNFishjamClientModule from '../RNFishjamClientModule';
+import { useFishjamEventState } from './useFishjamEventState';
 
 /**
  * Represents the possible statuses of a peer connection to a room (websocket state).
@@ -19,15 +19,10 @@ export type PeerStatus = 'connecting' | 'connected' | 'error' | 'idle';
  * @group Hooks
  */
 export const usePeerStatus = () => {
-  const [peerStatus, setPeerStatus] = useState(
+  const peerStatus = useFishjamEventState<PeerStatus>(
+    ReceivableEvents.PeerStatusChanged,
     RNFishjamClientModule.peerStatus,
   );
-
-  const onPeerStatusChanged = useCallback((status?: PeerStatus) => {
-    status && setPeerStatus(status);
-  }, []);
-
-  useFishjamEvent(ReceivableEvents.PeerStatusChanged, onPeerStatusChanged);
 
   return { peerStatus };
 };

--- a/packages/react-native-client/src/hooks/useScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useScreenShare.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 
 import {
   BandwidthLimit,
@@ -9,7 +9,8 @@ import {
 } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
 import { Platform } from 'react-native';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
+import { useFishjamEventState } from './useFishjamEventState';
 
 export type ScreenShareQuality = 'VGA' | 'HD5' | 'HD15' | 'FHD15' | 'FHD30';
 
@@ -48,21 +49,19 @@ let screenShareSimulcastConfig: SimulcastConfig = defaultSimulcastConfig();
  * @group Hooks
  */
 export function useScreenShare() {
-  const [isScreenShareOn, setIsScreenShareOn] = useState(
+  const isScreenShareOn = useFishjamEventState<boolean>(
+    ReceivableEvents.IsScreenShareOn,
     RNFishjamClientModule.isScreenShareOn,
   );
 
-  const [simulcastConfig, setSimulcastConfig] = useState<SimulcastConfig>(
+  const simulcastConfig = useFishjamEventState<SimulcastConfig>(
+    ReceivableEvents.SimulcastConfigUpdate,
     screenShareSimulcastConfig,
   );
 
-  useFishjamEvent(ReceivableEvents.IsScreenShareOn, setIsScreenShareOn);
-
   const toggleScreenShareTrackEncoding = useCallback(
     async (encoding: TrackEncoding) => {
-      screenShareSimulcastConfig =
-        await RNFishjamClientModule.toggleScreenShareTrackEncoding(encoding);
-      setSimulcastConfig(screenShareSimulcastConfig);
+      await RNFishjamClientModule.toggleScreenShareTrackEncoding(encoding);
     },
     [],
   );
@@ -108,7 +107,6 @@ export function useScreenShare() {
       };
       await RNFishjamClientModule.toggleScreenShare(options);
       screenShareSimulcastConfig = defaultSimulcastConfig(); //to do: sync with camera settings
-      setSimulcastConfig(screenShareSimulcastConfig);
     },
     [isScreenShareOn, handleScreenSharePermission],
   );


### PR DESCRIPTION
## Description

Refactored `useAppScreenShare`, `useScreenShare`, `usePeerStatus`, `useBandwithEstimation` code to use `useFishjamEventState` instead of `useState` and `useFishjamEvent`.

## Motivation and Context

The code will be simpler and less error-prone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
