### PR TITLE
[FCE-830] Make usePeers stateless

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
@@ -155,6 +155,10 @@ class RNFishjamClientModule : Module() {
         return@Property rnFishjamClient.peerStatus
       }
 
+      Function("getPeers") {
+        return@Function rnFishjamClient.getPeers()
+      }
+
       AsyncFunction(
         "joinRoom"
       ) { url: String, peerToken: String, peerMetadata: Map<String, Any>, config: ConnectConfig, promise: Promise ->
@@ -212,12 +216,6 @@ class RNFishjamClientModule : Module() {
       AsyncFunction("toggleScreenShare") Coroutine { screenShareOptions: ScreenShareOptions ->
         withContext(Dispatchers.Main) {
           rnFishjamClient.toggleScreenShare(screenShareOptions)
-        }
-      }
-
-      AsyncFunction("getPeers") Coroutine { ->
-        withContext(Dispatchers.Main) {
-          rnFishjamClient.getPeers()
         }
       }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -480,7 +480,7 @@ class RNFishjamClient: FishjamClientListener {
         return [localEndpoint] + remoteEndpoints
     }
 
-    func getPeers() throws -> [[String: Any?]] {
+    func getPeers() -> [[String: Any?]] {
         let endpoints = RNFishjamClient.getLocalAndRemoteEndpoints()
         return endpoints.compactMap { endpoint in
             [
@@ -759,7 +759,7 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func emitEndpoints() {
-        emit(event: .peersUpdate(peersData: (try? getPeers()) ?? []))
+        emit(event: .peersUpdate(peersData: getPeers()))
     }
 
     func onJoined(peerID: String, peersInRoom: [String: Endpoint]) {

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -114,6 +114,10 @@ public class RNFishjamClientModule: Module {
             return rnFishjamClient.isAppScreenShareOn
         }
 
+        Function("getPeers") {
+            return rnFishjamClient.getPeers()
+        }
+
         AsyncFunction("joinRoom") {
             (
                 url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig,
@@ -154,10 +158,6 @@ public class RNFishjamClientModule: Module {
 
         AsyncFunction("toggleAppScreenShare") { (screenShareOptions: ScreenShareOptions) in
             try rnFishjamClient.toggleAppScreenShare(screenShareOptions: screenShareOptions)
-        }
-
-        AsyncFunction("getPeers") {
-            try rnFishjamClient.getPeers()
         }
 
         AsyncFunction("updatePeerMetadata") { (metadata: [String: Any]) in

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -20,6 +20,12 @@ type RNFishjamClient = {
   cameras: ReadonlyArray<Camera>;
   currentCamera: Camera | null;
   peerStatus: PeerStatus;
+
+  getPeers: <
+    PeerMetadataType extends Metadata,
+    ServerMetadata extends Metadata = GenericMetadata,
+  >() => Peer<PeerMetadataType, ServerMetadata>[];
+
   joinRoom: (
     url: string,
     peerToken: string,
@@ -39,10 +45,6 @@ type RNFishjamClient = {
   toggleAppScreenShare: (
     screenShareOptions: Partial<ScreenShareOptionsInternal>,
   ) => Promise<void>;
-  getPeers: <
-    PeerMetadataType extends Metadata,
-    ServerMetadata extends Metadata = GenericMetadata,
-  >() => Promise<Peer<PeerMetadataType, ServerMetadata>[]>;
   updatePeerMetadata: <MetadataType extends Metadata>(
     metadata: MetadataType,
   ) => Promise<void>;

--- a/packages/react-native-client/src/hooks/useFishjamEventState.ts
+++ b/packages/react-native-client/src/hooks/useFishjamEventState.ts
@@ -4,9 +4,7 @@ import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
 export function useFishjamEventState<EventType, StateType = EventType>(
   eventName: keyof typeof ReceivableEvents,
   defaultValue: StateType,
-  transform?: StateType extends EventType
-    ? undefined
-    : (eventValue: EventType) => StateType,
+  transform?: (eventValue: EventType) => StateType,
 ) {
   const [value, setValue] = useState<StateType>(defaultValue);
 

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { Brand, GenericMetadata, TrackEncoding, TrackMetadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -182,11 +182,8 @@ export function usePeers<
 >(): UsePeersResult<PeerMetadata, ServerMetadata> {
   const peers = useFishjamEventState<Peer<PeerMetadata, ServerMetadata>[]>(
     ReceivableEvents.PeersUpdate,
-    RNFishjamClientModule.getPeers<
-        PeerMetadata,
-        ServerMetadata
-      >(),
-    (peers) => addIsActiveToTracks(peers)
+    RNFishjamClientModule.getPeers<PeerMetadata, ServerMetadata>(),
+    (peers) => addIsActiveToTracks(peers),
   );
 
   const localPeer = useMemo(() => {

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { Brand, GenericMetadata, TrackEncoding, TrackMetadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
+import { useFishjamEventState } from './useFishjamEventState';
 
 export type PeerId = Brand<string, 'PeerId'>;
 export type TrackId = Brand<string, 'TrackId'>;
@@ -179,7 +180,14 @@ export function usePeers<
   PeerMetadata extends GenericMetadata = GenericMetadata,
   ServerMetadata extends GenericMetadata = GenericMetadata,
 >(): UsePeersResult<PeerMetadata, ServerMetadata> {
-  const [peers, setPeers] = useState<Peer<PeerMetadata, ServerMetadata>[]>([]);
+  const peers = useFishjamEventState<Peer<PeerMetadata, ServerMetadata>[]>(
+    ReceivableEvents.PeersUpdate,
+    RNFishjamClientModule.getPeers<
+        PeerMetadata,
+        ServerMetadata
+      >(),
+    (peers) => addIsActiveToTracks(peers)
+  );
 
   const localPeer = useMemo(() => {
     const localPeerData = peers.find((peer) => peer.isLocal);
@@ -191,27 +199,6 @@ export function usePeers<
       peers.filter((peer) => !peer.isLocal).map(getPeerWithDistinguishedTracks),
     [peers],
   );
-
-  const updateActivePeers = useCallback(
-    (peers: Peer<PeerMetadata, ServerMetadata>[]) => {
-      setPeers(addIsActiveToTracks(peers));
-    },
-    [],
-  );
-
-  useFishjamEvent(ReceivableEvents.PeersUpdate, updateActivePeers);
-
-  useEffect(() => {
-    async function updatePeers() {
-      const peers = await RNFishjamClientModule.getPeers<
-        PeerMetadata,
-        ServerMetadata
-      >();
-      updateActivePeers(peers);
-    }
-
-    updatePeers();
-  }, [updateActivePeers]);
 
   return { localPeer, remotePeers, peers };
 }

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -183,7 +183,7 @@ export function usePeers<
   const peers = useFishjamEventState<Peer<PeerMetadata, ServerMetadata>[]>(
     ReceivableEvents.PeersUpdate,
     RNFishjamClientModule.getPeers<PeerMetadata, ServerMetadata>(),
-    (peers) => addIsActiveToTracks(peers),
+    (peersWithoutActive) => addIsActiveToTracks(peersWithoutActive),
   );
 
   const localPeer = useMemo(() => {


### PR DESCRIPTION
## Description

Refactored `usePeers` code to use `useFishjamEventState` instead of `useState` and `useFishjamEvent`.

## Motivation and Context

The code will be simpler and less error-prone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
