### PR TITLE
FCE-820: Fix peer and server metadata

### DIFF
--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -79,10 +79,7 @@ function PreviewScreen({
       route.params.fishjamUrl,
       route.params.peerToken,
       {
-        peer: {
-          displayName: route.params.userName,
-        },
-        server: {},
+        displayName: route.params.userName,
       },
     );
 

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -209,7 +209,7 @@ internal class FishjamClientInternal(
     coroutineScope.launch {
       commandsQueue.addCommand(
         Command(CommandName.JOIN, ClientState.JOINED) {
-          localEndpoint = localEndpoint.copy(metadata = connectConfig?.peerMetadata)
+          localEndpoint = localEndpoint.copy(metadata = mapOf("peer" to connectConfig?.peerMetadata, "server" to mapOf())) // TODO: Remove after FCE-834
           rtcEngineCommunication.connect(connectConfig?.peerMetadata ?: emptyMap())
         }
       )
@@ -465,7 +465,7 @@ internal class FishjamClientInternal(
   fun updatePeerMetadata(peerMetadata: Metadata) {
     coroutineScope.launch {
       rtcEngineCommunication.updatePeerMetadata(peerMetadata)
-      localEndpoint = localEndpoint.copy(metadata = peerMetadata)
+      localEndpoint = localEndpoint.copy(metadata = mapOf("peer" to connectConfig?.peerMetadata, "server" to mapOf())) // TODO: Remove after FCE-834
     }
   }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -86,8 +86,11 @@ class FishjamClientInternal {
     func join() {
         commandsQueue.addCommand(
             Command(commandName: .JOIN, clientStateAfterCommand: .JOINED) {
-                self.localEndpoint = self.localEndpoint.copyWith(metadata: self.config?.peerMetadata)
-                self.rtcEngineCommunication.connect(metadata: self.localEndpoint.metadata)
+                self.localEndpoint = self.localEndpoint.copyWith(metadata: [
+                    "peer": self.config?.peerMetadata.toDict() as Any, // TODO: Remove after FCE-834
+                    "server": [:]
+                ].toMetadata())
+                self.rtcEngineCommunication.connect(metadata: self.config?.peerMetadata ?? [:].toMetadata())
             })
     }
 
@@ -290,7 +293,10 @@ class FishjamClientInternal {
 
     func updatePeerMetadata(metadata: Metadata) {
         rtcEngineCommunication.updateEndpointMetadata(metadata: metadata)
-        localEndpoint = localEndpoint.copyWith(metadata: metadata)
+        localEndpoint = localEndpoint.copyWith(metadata: [
+            "peer": self.config?.peerMetadata.toDict() as Any, // TODO: Remove after FCE-834
+            "server": [:]
+        ].toMetadata())
     }
 
     func updateTrackMetadata(trackId: String, metadata: Metadata) {

--- a/packages/ios-client/Sources/FishjamClient/utils/types.swift
+++ b/packages/ios-client/Sources/FishjamClient/utils/types.swift
@@ -1,3 +1,24 @@
 public typealias Metadata = AnyJson
 public typealias Payload = AnyJson
 public typealias SerializedMediaEvent = String
+
+
+public extension [String: Any] {
+    func toMetadata() -> Metadata {
+        var res: Metadata = .init()
+        self.forEach { entry in
+            res[entry.key] = entry.value
+        }
+        return res
+    }
+}
+
+public extension AnyJson {
+    func toDict() -> [String: Any] {
+        var res: [String: Any] = [:]
+        self.keys.forEach { key in
+            res[key] = self[key]
+        }
+        return res
+    }
+}

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -19,7 +19,6 @@ class RNFishjamClient: FishjamClientListener {
     var connectPromise: Promise? = nil
 
     var videoSimulcastConfig: SimulcastConfig = SimulcastConfig()
-    var localUserMetadata: Metadata = .init()
 
     var screenShareSimulcastConfig: SimulcastConfig = SimulcastConfig()
     var screenShareMaxBandwidth: TrackBandwidthLimit = .BandwidthLimit(0)
@@ -207,7 +206,6 @@ class RNFishjamClient: FishjamClientListener {
     ) {
         peerStatus = .connecting
         connectPromise = promise
-        localUserMetadata = ["server": [:], "peer": peerMetadata].toMetadata()
 
         let reconnectConfig = FishjamCloudClient.ReconnectConfig(
             maxAttempts: config.reconnectConfig.maxAttempts, initialDelayMs: config.reconnectConfig.initialDelayMs,

--- a/packages/react-native-client/ios/Utils.swift
+++ b/packages/react-native-client/ios/Utils.swift
@@ -21,23 +21,3 @@ let log = OSLog(subsystem: "com.fishjamcloud.react-native-client", category: "Er
         }
     }
 #endif
-
-extension [String: Any] {
-    public func toMetadata() -> Metadata {
-        var res: Metadata = .init()
-        self.forEach { entry in
-            res[entry.key] = entry.value
-        }
-        return res
-    }
-}
-
-extension AnyJson {
-    public func toDict() -> [String: Any] {
-        var res: [String: Any] = [:]
-        self.keys.forEach { key in
-            res[key] = self[key]
-        }
-        return res
-    }
-}

--- a/packages/react-native-client/src/common/client.ts
+++ b/packages/react-native-client/src/common/client.ts
@@ -1,6 +1,5 @@
 import { GenericMetadata } from '../types';
 import RNFishjamClientModule from '../RNFishjamClientModule';
-import { PeerTrackMetadata } from '../hooks/usePeers';
 
 export type ConnectionConfig = {
   /**
@@ -27,11 +26,10 @@ export type ConnectionConfig = {
  */
 export async function joinRoom<
   PeerMetadata extends GenericMetadata = GenericMetadata,
-  ServerMetadata extends GenericMetadata = GenericMetadata,
 >(
   url: string,
   peerToken: string,
-  peerMetadata?: PeerTrackMetadata<PeerMetadata, ServerMetadata>,
+  peerMetadata?: PeerMetadata,
   config?: ConnectionConfig,
 ) {
   await RNFishjamClientModule.joinRoom(


### PR DESCRIPTION
## Description

- Temporary fix for metadata, should be changed to only use metadata from RTC Engine after  https://linear.app/swmansion/issue/FCE-834 is merged

## Motivation and Context

- Mobile app was sending wrong metadata.

## How has this been tested?

- Run and tested Android + iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.