### PR TITLE
[FCE-852] Make useAudioSettings stateless

### DIFF
--- a/packages/react-native-client/src/hooks/useAudioSettings.ts
+++ b/packages/react-native-client/src/hooks/useAudioSettings.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Platform } from 'react-native';
 
 import RNFishjamClientModule from '../RNFishjamClientModule';
-import { ReceivableEvents, useFishjamEvent } from './useFishjamEvent';
+import { ReceivableEvents } from './useFishjamEvent';
+import { useFishjamEventState } from './useFishjamEventState';
 
 export type AudioOutputDeviceType =
   | 'bluetooth'
@@ -18,7 +19,7 @@ export type AudioOutputDevice = {
 };
 
 type OnAudioDeviceEvent = {
-  selectedDevice: AudioOutputDevice;
+  selectedDevice: AudioOutputDevice | null;
   availableDevices: AudioOutputDevice[];
 };
 
@@ -28,18 +29,13 @@ type OnAudioDeviceEvent = {
  * @group Hooks
  */
 export function useAudioSettings() {
-  const [selectedAudioOutputDevice, setSelectedAudioOutputDevice] =
-    useState<AudioOutputDevice | null>(null);
-  const [availableDevices, setAvailableDevices] = useState<AudioOutputDevice[]>(
-    [],
+  const { selectedDevice: selectedAudioOutputDevice, availableDevices } = useFishjamEventState<OnAudioDeviceEvent>(
+    ReceivableEvents.AudioDeviceUpdate,
+    {
+      selectedDevice: null,
+      availableDevices: []
+    },
   );
-
-  const onAudioDevice = useCallback((event: OnAudioDeviceEvent) => {
-    setSelectedAudioOutputDevice(event.selectedDevice);
-    setAvailableDevices(event.availableDevices);
-  }, []);
-
-  useFishjamEvent(ReceivableEvents.AudioDeviceUpdate, onAudioDevice);
 
   useEffect(() => {
     RNFishjamClientModule.startAudioSwitcher();
@@ -48,7 +44,7 @@ export function useAudioSettings() {
         RNFishjamClientModule.stopAudioSwitcher();
       }
     };
-  }, [onAudioDevice]);
+  }, []);
 
   const selectOutputAudioDevice = useCallback(
     async (device: AudioOutputDeviceType) => {

--- a/packages/react-native-client/src/hooks/useAudioSettings.ts
+++ b/packages/react-native-client/src/hooks/useAudioSettings.ts
@@ -29,13 +29,14 @@ type OnAudioDeviceEvent = {
  * @group Hooks
  */
 export function useAudioSettings() {
-  const { selectedDevice: selectedAudioOutputDevice, availableDevices } = useFishjamEventState<OnAudioDeviceEvent>(
-    ReceivableEvents.AudioDeviceUpdate,
-    {
-      selectedDevice: null,
-      availableDevices: []
-    },
-  );
+  const { selectedDevice: selectedAudioOutputDevice, availableDevices } =
+    useFishjamEventState<OnAudioDeviceEvent>(
+      ReceivableEvents.AudioDeviceUpdate,
+      {
+        selectedDevice: null,
+        availableDevices: [],
+      },
+    );
 
   useEffect(() => {
     RNFishjamClientModule.startAudioSwitcher();


### PR DESCRIPTION
## Description

Refactored `useAudioSettings` code to use `useFishjamEventState` instead of `useState` and `useFishjamEvent`.

## Motivation and Context

The code will be simpler and less error-prone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
