### PR TITLE
[FCE-931] Unify joinRoom signature with web

### DIFF
--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -75,13 +75,13 @@ function PreviewScreen({
   }, [prepareCamera, navigation, leaveRoom]);
 
   const onJoinPressed = async () => {
-    await joinRoom<PeerMetadata>(
-      route.params.fishjamUrl,
-      route.params.peerToken,
-      {
+    await joinRoom<PeerMetadata>({
+      url: route.params.fishjamUrl,
+      peerToken: route.params.peerToken,
+      peerMetadata: {
         displayName: route.params.userName,
       },
-    );
+    });
 
     unsubscribeBeforeRemove();
 

--- a/packages/react-native-client/src/hooks/internal/useFishjamEvent.ts
+++ b/packages/react-native-client/src/hooks/internal/useFishjamEvent.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import nativeModule, { ReceivableEvents } from '../RNFishjamClientModule';
+import nativeModule, { ReceivableEvents } from '../../RNFishjamClientModule';
 
 export function useFishjamEvent<T>(
   eventName: keyof typeof ReceivableEvents,

--- a/packages/react-native-client/src/hooks/internal/useFishjamEventState.ts
+++ b/packages/react-native-client/src/hooks/internal/useFishjamEventState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useFishjamEvent } from './useFishjamEvent';
-import { ReceivableEvents } from '../RNFishjamClientModule';
+import { ReceivableEvents } from '../../RNFishjamClientModule';
 
 export function useFishjamEventState<EventType, StateType = EventType>(
   eventName: keyof typeof ReceivableEvents,

--- a/packages/react-native-client/src/hooks/useAppScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useAppScreenShare.ts
@@ -5,7 +5,7 @@ import RNFishjamClientModule, {
 import { SimulcastConfig } from '../types';
 import { ScreenShareOptions } from './useScreenShare';
 import { Platform } from 'react-native';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 const defaultSimulcastConfig = () => ({
   enabled: false,

--- a/packages/react-native-client/src/hooks/useAudioSettings.ts
+++ b/packages/react-native-client/src/hooks/useAudioSettings.ts
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 export type AudioOutputDeviceType =
   | 'bluetooth'

--- a/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
+++ b/packages/react-native-client/src/hooks/useBandwidthEstimation.ts
@@ -1,5 +1,5 @@
 import { ReceivableEvents } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 /**
  * This hook provides current bandwidth estimation

--- a/packages/react-native-client/src/hooks/useCamera.ts
+++ b/packages/react-native-client/src/hooks/useCamera.ts
@@ -12,7 +12,7 @@ import {
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 export type CameraId = Brand<string, 'CameraId'>;
 

--- a/packages/react-native-client/src/hooks/useConnection.ts
+++ b/packages/react-native-client/src/hooks/useConnection.ts
@@ -4,7 +4,7 @@ import { ConnectionConfig, joinRoom, leaveRoom } from '../common/client';
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 import { GenericMetadata } from '../types';
 
 type ReconnectionStatus = 'idle' | 'reconnecting' | 'error';

--- a/packages/react-native-client/src/hooks/useConnection.ts
+++ b/packages/react-native-client/src/hooks/useConnection.ts
@@ -1,9 +1,11 @@
-import { joinRoom, leaveRoom } from '../common/client';
+import { useCallback } from 'react';
+import { ConnectionConfig, joinRoom, leaveRoom } from '../common/client';
 
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
 import { useFishjamEventState } from './useFishjamEventState';
+import { GenericMetadata } from '../types';
 
 type ReconnectionStatus = 'idle' | 'reconnecting' | 'error';
 type PeerStatus = 'connecting' | 'connected' | 'error' | 'idle';
@@ -23,6 +25,26 @@ function useConnectionStatus() {
 
   return { peerStatus, reconnectionStatus };
 }
+export interface JoinRoomConfig<
+  PeerMetadata extends GenericMetadata = GenericMetadata,
+> {
+  /**
+   * fishjam URL
+   */
+  url: string;
+  /**
+   * token received from server (or Room Manager)
+   */
+  peerToken: string;
+  /**
+   * string indexed record with metadata, that will be available to all other peers
+   */
+  peerMetadata?: PeerMetadata;
+  /**
+   *  additional connection configuration
+   */
+  config?: ConnectionConfig;
+}
 
 /**
  * Connect/leave room. And get connection status.
@@ -35,15 +57,23 @@ export function useConnection() {
   const connectionStatus: ConnectionStatus =
     reconnectionStatus === 'idle' ? peerStatus : reconnectionStatus;
 
+  const join = useCallback(
+    async <PeerMetadata extends GenericMetadata = GenericMetadata>({
+      url,
+      peerToken,
+      peerMetadata,
+      config,
+    }: JoinRoomConfig<PeerMetadata>) => {
+      await joinRoom(url, peerToken, peerMetadata, config);
+    },
+    [],
+  );
+
   return {
     /**
      * join room and start streaming camera and microphone
-     * @param url fishjam Url
-     * @param peerToken token received from server (or Room Manager)
-     * @param peerMetadata string indexed record with metadata, that will be available to all other peers
-     * @param config additional connection configuration
      */
-    joinRoom,
+    joinRoom: join,
     /**
      * Leave room and stop streaming
      */

--- a/packages/react-native-client/src/hooks/useMicrophone.ts
+++ b/packages/react-native-client/src/hooks/useMicrophone.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 /**
  * This hook can toggle microphone on/off and provides current microphone state.

--- a/packages/react-native-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-native-client/src/hooks/usePeerStatus.ts
@@ -1,7 +1,7 @@
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 /**
  * Represents the possible statuses of a peer connection to a room (websocket state).

--- a/packages/react-native-client/src/hooks/usePeers.ts
+++ b/packages/react-native-client/src/hooks/usePeers.ts
@@ -4,7 +4,7 @@ import { Brand, GenericMetadata, TrackEncoding, TrackMetadata } from '../types';
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 export type PeerId = Brand<string, 'PeerId'>;
 export type TrackId = Brand<string, 'TrackId'>;

--- a/packages/react-native-client/src/hooks/useReconnection.ts
+++ b/packages/react-native-client/src/hooks/useReconnection.ts
@@ -1,7 +1,7 @@
 import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 export type ReconnectionStatus = 'idle' | 'reconnecting' | 'error';
 

--- a/packages/react-native-client/src/hooks/useScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useScreenShare.ts
@@ -11,7 +11,7 @@ import RNFishjamClientModule, {
   ReceivableEvents,
 } from '../RNFishjamClientModule';
 import { Platform } from 'react-native';
-import { useFishjamEventState } from './useFishjamEventState';
+import { useFishjamEventState } from './internal/useFishjamEventState';
 
 export type ScreenShareQuality = 'VGA' | 'HD5' | 'HD15' | 'FHD15' | 'FHD30';
 

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -67,7 +67,7 @@ export type {
 export type { ReconnectionStatus } from './hooks/useReconnection';
 export type { PeerStatus } from './hooks/usePeerStatus';
 export type { ForegroundServiceConfig } from './hooks/useForegroundService';
-export type { ConnectionStatus } from './hooks/useConnection';
+export type { ConnectionStatus, JoinRoomConfig } from './hooks/useConnection';
 // #endregion
 
 // #region hooks


### PR DESCRIPTION
## Description

This is change in `joinRoom` API where it will be unified with web API - param will be object.

Here is related change in web SDK: https://github.com/fishjam-cloud/web-client-sdk/pull/206
Here is related change in documentation: https://github.com/fishjam-cloud/documentation/pull/62

## Motivation and Context

We should aim for similar API on all platforms, and this is yet another step to unify it (this time Web part had better approach)

## How has this been tested?

This is 'just' a change in method typing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
