### PR TITLE
Skip dependency version check when running expo doctor

### DIFF
--- a/.github/workflows/expo_doctor.yaml
+++ b/.github/workflows/expo_doctor.yaml
@@ -18,5 +18,5 @@ jobs:
         run: yarn && yarn build
 
       - name: 🩺 Run Expo Doctor
-        run: npx expo-doctor@latest
+        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest
         working-directory: examples/fishjam-chat


### PR DESCRIPTION
## Description

- Skip dependency version check when running expo doctor

## Motivation and Context

- It was annoying that it failed on unrelated PRs. 

## How has this been tested?

- Tested locally.
- 
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
