### PR TITLE
FCE-1023: Change how prepareCamera works

### DIFF
--- a/examples/fishjam-chat/app.json
+++ b/examples/fishjam-chat/app.json
@@ -21,8 +21,7 @@
         "NSCameraUsageDescription": "We need to access your camera for video calls.",
         "NSMicrophoneUsageDescription": "We need to access your microphone so you can talk during calls.",
         "ITSAppUsesNonExemptEncryption": false
-      },
-      "appleTeamId": "J5FM626PE2"
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/examples/fishjam-chat/app.json
+++ b/examples/fishjam-chat/app.json
@@ -69,9 +69,7 @@
           }
         }
       ],
-      [
-        "./plugin/build/with-local-paths-for-native-packages.js"
-      ]
+      ["./plugin/build/with-local-paths-for-native-packages.js"]
     ],
     "extra": {
       "eas": {

--- a/examples/fishjam-chat/app.json
+++ b/examples/fishjam-chat/app.json
@@ -16,12 +16,13 @@
       "bundleIdentifier": "io.fishjam.example.fishjamchat",
       "infoPlist": {
         "NSAppTransportSecurity": {
-          "NSAllowsArbitraryLoads": true //this allows for testing in local network without secured connections
+          "NSAllowsArbitraryLoads": true
         },
         "NSCameraUsageDescription": "We need to access your camera for video calls.",
         "NSMicrophoneUsageDescription": "We need to access your microphone so you can talk during calls.",
         "ITSAppUsesNonExemptEncryption": false
-      }
+      },
+      "appleTeamId": "J5FM626PE2"
     },
     "android": {
       "adaptiveIcon": {
@@ -69,7 +70,7 @@
         }
       ],
       [
-        "./plugin/build/with-local-paths-for-native-packages.js" // Only relevant for local development of packages/ios-client and packages/android-client
+        "./plugin/build/with-local-paths-for-native-packages.js"
       ]
     ],
     "extra": {

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/EmitableEvents.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/EmitableEvents.kt
@@ -53,12 +53,14 @@ class EmitableEvent private constructor(
 
     fun currentCameraChanged(
       localCamera: LocalCamera?,
-      isCameraOn: Boolean
+      isCameraOn: Boolean,
+      isCameraInitialized: Boolean
     ) = EmitableEvent(
       EventName.CurrentCameraChanged,
       mapOf(
         "currentCamera" to localCamera,
-        "isCameraOn" to isCameraOn
+        "isCameraOn" to isCameraOn,
+        "isCameraInitialized" to isCameraInitialized
       )
     )
 

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -54,7 +54,17 @@ class RNFishjamClient(
   var isScreenShareOn = false
   var isConnected = false
 
-  private var isCameraInitialized = false
+  var isCameraInitialized = false
+    private set(value) {
+      field = value
+      emitEvent(
+        EmitableEvent.currentCameraChanged(
+          getCurrentCaptureDevice(),
+          isCameraOn,
+          value
+        )
+      )
+    }
 
   private var connectPromise: Promise? = null
   private var screenSharePermissionPromise: Promise? = null
@@ -293,7 +303,6 @@ class RNFishjamClient(
 
   suspend fun startCamera(config: CameraConfig): Boolean {
     if (isCameraInitialized) {
-      emitEvent(EmitableEvent.warning("Camera already started. You may only call startCamera once before leaveRoom is called."))
       return true
     }
     if (!PermissionUtils.requestCameraPermission(appContext)) {
@@ -325,7 +334,13 @@ class RNFishjamClient(
   ) {
     cameraTrack.setEnabled(isEnabled)
     isCameraOn = isEnabled
-    emitEvent(EmitableEvent.currentCameraChanged(cameraTrack.getCaptureDevice()?.toLocalCamera(), isEnabled))
+    emitEvent(
+      EmitableEvent.currentCameraChanged(
+        cameraTrack.getCaptureDevice()?.toLocalCamera(),
+        isEnabled,
+        isCameraInitialized
+      )
+    )
     localCameraTracksChangedListenersManager.notifyListeners()
   }
 
@@ -496,7 +511,8 @@ class RNFishjamClient(
     }
   }
 
-  fun getCurrentCaptureDevice(): Map<String, Any>? = getLocalVideoTrack()?.getCaptureDevice()?.toLocalCamera()
+  fun getCurrentCaptureDevice(): Map<String, Any>? =
+    getLocalVideoTrack()?.getCaptureDevice()?.toLocalCamera()
 
   fun updatePeerMetadata(metadata: Metadata) {
     ensureConnected()
@@ -905,6 +921,12 @@ class RNFishjamClient(
   }
 
   override fun onCaptureDeviceChanged(captureDevice: CaptureDevice?) {
-    emitEvent(EmitableEvent.currentCameraChanged(captureDevice?.toLocalCamera(), isCameraOn))
+    emitEvent(
+      EmitableEvent.currentCameraChanged(
+        captureDevice?.toLocalCamera(),
+        isCameraOn,
+        isCameraInitialized
+      )
+    )
   }
 }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -511,8 +511,7 @@ class RNFishjamClient(
     }
   }
 
-  fun getCurrentCaptureDevice(): Map<String, Any>? =
-    getLocalVideoTrack()?.getCaptureDevice()?.toLocalCamera()
+  fun getCurrentCaptureDevice(): Map<String, Any>? = getLocalVideoTrack()?.getCaptureDevice()?.toLocalCamera()
 
   fun updatePeerMetadata(metadata: Metadata) {
     ensureConnected()

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
@@ -159,6 +159,10 @@ class RNFishjamClientModule : Module() {
         return@Property rnFishjamClient.reconnectionStatus.status
       }
 
+      Property("isCameraInitialized") {
+        return@Property rnFishjamClient.isCameraInitialized
+      }
+
       Function("getPeers") {
         return@Function rnFishjamClient.getPeers()
       }

--- a/packages/react-native-client/ios/Events.swift
+++ b/packages/react-native-client/ios/Events.swift
@@ -57,12 +57,13 @@ class EmitableEvent {
         .init(event: .ReconnectionStatusChanged, eventContent: reconnectionStatus.rawValue)
     }
 
-    static func currentCameraChanged(localCamera: LocalCamera?, isCameraOn: Bool) -> EmitableEvent {
+    static func currentCameraChanged(localCamera: LocalCamera?, isCameraOn: Bool, isCameraInitialized: Bool) -> EmitableEvent {
         return .init(
             event: .CurrentCameraChanged,
             eventContent: [
                 "currentCamera": localCamera as Any,
                 "isCameraOn": isCameraOn,
+                "isCameraInitialized": isCameraInitialized
             ])
     }
 

--- a/packages/react-native-client/ios/Events.swift
+++ b/packages/react-native-client/ios/Events.swift
@@ -57,13 +57,15 @@ class EmitableEvent {
         .init(event: .ReconnectionStatusChanged, eventContent: reconnectionStatus.rawValue)
     }
 
-    static func currentCameraChanged(localCamera: LocalCamera?, isCameraOn: Bool, isCameraInitialized: Bool) -> EmitableEvent {
+    static func currentCameraChanged(localCamera: LocalCamera?, isCameraOn: Bool, isCameraInitialized: Bool)
+        -> EmitableEvent
+    {
         return .init(
             event: .CurrentCameraChanged,
             eventContent: [
                 "currentCamera": localCamera as Any,
                 "isCameraOn": isCameraOn,
-                "isCameraInitialized": isCameraInitialized
+                "isCameraInitialized": isCameraInitialized,
             ])
     }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -14,7 +14,11 @@ class RNFishjamClient: FishjamClientListener {
     var isAppScreenShareOn = false
     var isConnected = false
 
-    private var isCameraInitialized = false
+    private(set) var isCameraInitialized = false {
+        didSet {
+            emit(event: .currentCameraChanged(localCamera: currentCamera, isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
+        }
+    }
 
     var connectPromise: Promise? = nil
 
@@ -254,11 +258,6 @@ class RNFishjamClient: FishjamClientListener {
             try ensureCreated()
 
             guard !isCameraInitialized else {
-                emit(
-                    event: .warning(
-                        message:
-                            "Camera already started. You may only call startCamera once before leaveRoom is called."))
-
                 return true
             }
 
@@ -292,7 +291,7 @@ class RNFishjamClient: FishjamClientListener {
         isCameraOn = enabled
         emit(
             event: .currentCameraChanged(
-                localCamera: cameraTrack.currentCaptureDevice?.toLocalCamera(), isCameraOn: enabled))
+                localCamera: cameraTrack.currentCaptureDevice?.toLocalCamera(), isCameraOn: enabled, isCameraInitialized: isCameraInitialized))
         RNFishjamClient.localCameraTracksChangedListenersManager.notifyListeners()
     }
 
@@ -913,6 +912,6 @@ class RNFishjamClient: FishjamClientListener {
 
 extension RNFishjamClient: CameraCapturerDeviceChangedListener {
     func onCaptureDeviceChanged(_ device: AVCaptureDevice?) {
-        emit(event: .currentCameraChanged(localCamera: device?.toLocalCamera(), isCameraOn: isCameraOn))
+        emit(event: .currentCameraChanged(localCamera: device?.toLocalCamera(), isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
     }
 }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -16,7 +16,9 @@ class RNFishjamClient: FishjamClientListener {
 
     private(set) var isCameraInitialized = false {
         didSet {
-            emit(event: .currentCameraChanged(localCamera: currentCamera, isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
+            emit(
+                event: .currentCameraChanged(
+                    localCamera: currentCamera, isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
         }
     }
 
@@ -291,7 +293,8 @@ class RNFishjamClient: FishjamClientListener {
         isCameraOn = enabled
         emit(
             event: .currentCameraChanged(
-                localCamera: cameraTrack.currentCaptureDevice?.toLocalCamera(), isCameraOn: enabled, isCameraInitialized: isCameraInitialized))
+                localCamera: cameraTrack.currentCaptureDevice?.toLocalCamera(), isCameraOn: enabled,
+                isCameraInitialized: isCameraInitialized))
         RNFishjamClient.localCameraTracksChangedListenersManager.notifyListeners()
     }
 
@@ -912,6 +915,8 @@ class RNFishjamClient: FishjamClientListener {
 
 extension RNFishjamClient: CameraCapturerDeviceChangedListener {
     func onCaptureDeviceChanged(_ device: AVCaptureDevice?) {
-        emit(event: .currentCameraChanged(localCamera: device?.toLocalCamera(), isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
+        emit(
+            event: .currentCameraChanged(
+                localCamera: device?.toLocalCamera(), isCameraOn: isCameraOn, isCameraInitialized: isCameraInitialized))
     }
 }

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -117,6 +117,10 @@ public class RNFishjamClientModule: Module {
         Property("isAppScreenShareOn") {
             return rnFishjamClient.isAppScreenShareOn
         }
+        
+        Property("isCameraInitialized") {
+            return rnFishjamClient.isCameraInitialized
+        }
 
         Function("getPeers") {
             return rnFishjamClient.getPeers()

--- a/packages/react-native-client/ios/RNFishjamClientModule.swift
+++ b/packages/react-native-client/ios/RNFishjamClientModule.swift
@@ -117,7 +117,7 @@ public class RNFishjamClientModule: Module {
         Property("isAppScreenShareOn") {
             return rnFishjamClient.isAppScreenShareOn
         }
-        
+
         Property("isCameraInitialized") {
             return rnFishjamClient.isCameraInitialized
         }

--- a/packages/react-native-client/src/RNFishjamClientModule.ts
+++ b/packages/react-native-client/src/RNFishjamClientModule.ts
@@ -21,6 +21,7 @@ type RNFishjamClient = {
   currentCamera: Camera | null;
   peerStatus: PeerStatus;
   reconnectionStatus: ReconnectionStatus;
+  isCameraInitialized: boolean;
 
   getPeers: <
     PeerMetadataType extends Metadata,

--- a/packages/react-native-client/src/hooks/useCamera.ts
+++ b/packages/react-native-client/src/hooks/useCamera.ts
@@ -27,6 +27,7 @@ export type Camera = {
 export type CurrentCameraChangedType = {
   currentCamera: Camera | null;
   isCameraOn: boolean;
+  isCameraInitialized: boolean;
 };
 
 export type VideoQuality =
@@ -163,14 +164,18 @@ export function useCamera() {
     defaultSimulcastConfig(), // TODO: Fetch from native
   );
 
-  const { currentCamera: currentCameraState, isCameraOn } =
-    useFishjamEventState<CurrentCameraChangedType>(
-      ReceivableEvents.CurrentCameraChanged,
-      {
-        currentCamera: RNFishjamClientModule.currentCamera,
-        isCameraOn: RNFishjamClientModule.isCameraOn,
-      },
-    );
+  const {
+    currentCamera: currentCameraState,
+    isCameraOn,
+    isCameraInitialized,
+  } = useFishjamEventState<CurrentCameraChangedType>(
+    ReceivableEvents.CurrentCameraChanged,
+    {
+      currentCamera: RNFishjamClientModule.currentCamera,
+      isCameraOn: RNFishjamClientModule.isCameraOn,
+      isCameraInitialized: RNFishjamClientModule.isCameraInitialized,
+    },
+  );
 
   // For Android Expo converts null to undefined ¯\_(ツ)_/¯
   const currentCamera = currentCameraState ?? null;
@@ -248,6 +253,10 @@ export function useCamera() {
      * @returns A promise that resolves to the list of available cameras.
      */
     cameras,
+    /**
+     * A value indicating if camera was already initialized (if `prepareCamera` was called).
+     */
+    isInitialized: isCameraInitialized,
     /**
      * Enable/disable current camera
      */


### PR DESCRIPTION
## Description

- Removed warning when `prepareCamera` was called multiple times
- Added a property that indicates if the amera was already initialized

## Motivation and Context

- It was misleading for SDK users what this warning meant. 

## How has this been tested?

- Tested on iOS and Android.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.