### PR TITLE
[FCE-1039] Update types exports (and typedoc) to make `yarn docs` happy

### DIFF
--- a/.github/workflows/all_packages_lint.yaml
+++ b/.github/workflows/all_packages_lint.yaml
@@ -5,22 +5,32 @@ jobs:
   types_and_lint:
     runs-on: macos-14
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js 22
+
+      - name: Use Node 22 🛎️
         uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: "npm"
+
       - name: Use corepack
         run: corepack enable
-      - name: Install deps
+
+      - name: Install system deps 🍎
         run: brew install swift-format xcbeautify ktlint
-      - name: Install node dependencies
+
+      - name: Install node dependencies ⬇️
         run: yarn
-      - name: Build Types
+
+      - name: Build Types 📦
         run: yarn build
-      - name: Check types
+
+      - name: Check types 🚓
         run: yarn tsc
-      - name: Lint
+
+      - name: Run linter (and check formatting) 👮
         run: yarn lint:check
+
+      - name: Run docs generation 📘
+        run: yarn docs

--- a/packages/react-native-client/src/hooks/useAppScreenShare.ts
+++ b/packages/react-native-client/src/hooks/useAppScreenShare.ts
@@ -14,7 +14,7 @@ const defaultSimulcastConfig = () =>
 
 let screenShareSimulcastConfig: SimulcastConfig = defaultSimulcastConfig();
 
-type AppScreenShareData = {
+export type AppScreenShareData = {
   isAppScreenShareOn: boolean;
   simulcastConfig: SimulcastConfig;
   toggleAppScreenShare: (

--- a/packages/react-native-client/src/hooks/useCamera.ts
+++ b/packages/react-native-client/src/hooks/useCamera.ts
@@ -33,7 +33,7 @@ export type VideoQuality =
   | 'HD43'
   | 'FHD43';
 
-type CameraConfigBase = {
+export type CameraConfigBase = {
   /**
    * resolution + aspect ratio of local video track, one of: `QVGA_169`, `VGA_169`, `QHD_169`, `HD_169`,
    * `FHD_169`, `QVGA_43`, `VGA_43`, `QHD_43`, `HD_43`, `FHD_43`. Note that quality might be worse than

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -1,7 +1,13 @@
 import { initializeWarningListener } from './utils/errorListener';
 
 // #region types
-export type { SimulcastConfig, VideoLayout } from './types';
+export type {
+  SimulcastConfig,
+  VideoLayout,
+  GenericMetadata,
+  TrackMetadata,
+  Brand,
+} from './types';
 export type { ConnectionConfig } from './common/client';
 // #endregion
 
@@ -38,6 +44,7 @@ export type {
   UsePeersResult,
   PeerWithTracks,
   PeerTrackMetadata,
+  DistinguishedTracks,
 } from './hooks/usePeers';
 
 export type {
@@ -52,6 +59,7 @@ export type {
   CameraConfig,
   VideoQuality,
   CameraFacingDirection,
+  CameraConfigBase,
 } from './hooks/useCamera';
 
 export type {
@@ -64,6 +72,7 @@ export type {
   ReconnectionStatus,
   PeerStatus,
 } from './hooks/useConnection';
+export type { AppScreenShareData } from './hooks/useAppScreenShare';
 // #endregion
 
 // #region hooks

--- a/packages/react-native-client/src/types.ts
+++ b/packages/react-native-client/src/types.ts
@@ -28,4 +28,7 @@ export type GenericMetadata = Record<string, unknown>;
 
 // branded types are useful for restricting where given value can be passed
 declare const brand: unique symbol;
+/**
+ * Branded type
+ */
 export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,8 +1,11 @@
 {
-  "entryPoints": ["packages/*"],
+  "entryPoints": ["packages/react-native-client/*"],
   "name": "Fishjam Mobile SDK",
   "entryPointStrategy": "packages",
   "includeVersion": true,
   "plugin": ["typedoc-material-theme"],
-  "themeColor": "#FCF6E7"
+  "themeColor": "#FCF6E7",
+  "readme": "none",
+  "treatValidationWarningsAsErrors": true,
+  "treatWarningsAsErrors": true
 }


### PR DESCRIPTION
## Description

Export all types that are visible to end user, but were not yet exported
Fix typedoc syntax marked as incorrect
Update typedoc configuration to only generate docs for React Native package

I also updated workflow config - to add emojis (as on web) and new step that generate docs.

## Motivation and Context

I want to update our documentation, but as part of this process I want to remove warnings (and also add missing types into docs)

## How has this been tested?

Run all CI checks

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
