### PR TITLE
FCE-1042: Fix microphone track

### DIFF
--- a/packages/ios-client/Sources/FishjamClient/webrtc/helpers/TrackBitratesMapper.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/helpers/TrackBitratesMapper.swift
@@ -6,9 +6,7 @@ struct TrackBitratesMapper {
     {
         Dictionary(
             uniqueKeysWithValues: localTracks.compactMap {
-                t -> (String, Fishjam_MediaEvents_Peer_MediaEvent.TrackBitrates)? in
-                guard let track = t as? LocalCameraTrack else { return nil }
-
+                track -> (String, Fishjam_MediaEvents_Peer_MediaEvent.TrackBitrates)? in
                 let bitrates: [Fishjam_MediaEvents_Peer_MediaEvent.VariantBitrate] = track.sendEncodings.compactMap {
                     param in
                     guard let ridString = param.rid else { return nil }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -354,7 +354,7 @@ class RNFishjamClient(
       return
     }
 
-    val microphoneTrack = fishjamClient.createAudioTrack(emptyMap())
+    val microphoneTrack = fishjamClient.createAudioTrack(getMicrophoneTrackMetadata())
     setMicrophoneTrackState(microphoneTrack, true)
     emitEndpoints()
   }
@@ -375,16 +375,17 @@ class RNFishjamClient(
       getLocalAudioTrack()?.let { setMicrophoneTrackState(it, !isMicrophoneOn) }
     }
 
-    updateLocalAudioTrackMetadata(
-      mapOf(
-        "active" to isMicrophoneOn,
-        "paused" to !isMicrophoneOn, // TODO: FCE-711,
-        "type" to "microphone"
-      )
-    )
+    updateLocalAudioTrackMetadata(getMicrophoneTrackMetadata())
 
     return isMicrophoneOn
   }
+
+  private fun getMicrophoneTrackMetadata(): Map<String, Any> =
+    mapOf(
+      "active" to isMicrophoneOn,
+      "paused" to !isMicrophoneOn, // TODO: FCE-711,
+      "type" to "microphone"
+    )
 
   fun handleScreenSharePermission(promise: Promise) {
     screenSharePermissionPromise = promise

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -308,11 +308,7 @@ class RNFishjamClient: FishjamClientListener {
             try await startMicrophone()
         }
 
-        try updateLocalAudioTrackMetadata(metadata: [
-            "active": isMicrophoneOn,
-            "paused": !isMicrophoneOn,  //TODO: FCE-711
-            "type": "microphone",
-        ])
+        try updateLocalAudioTrackMetadata(metadata: getMicrophoneTrackMetadata())
 
         return isMicrophoneOn
     }
@@ -322,10 +318,19 @@ class RNFishjamClient: FishjamClientListener {
             emit(event: .warning(message: "Microphone permission not granted."))
             return
         }
-        let microphoneTrack = RNFishjamClient.fishjamClient!.createAudioTrack(metadata: Metadata())
+        let microphoneTrack = RNFishjamClient.fishjamClient!.createAudioTrack(
+            metadata: getMicrophoneTrackMetadata().toMetadata())
         setAudioSessionMode()
         setMicrophoneTrackState(microphoneTrack, enabled: true)
         emitEndpoints()
+    }
+
+    private func getMicrophoneTrackMetadata() -> [String: Any] {
+        return [
+            "active": isMicrophoneOn,
+            "paused": !isMicrophoneOn,  //TODO: FCE-711
+            "type": "microphone",
+        ]
     }
 
     private func setMicrophoneTrackState(_ microphoneTrack: LocalAudioTrack, enabled: Bool) {


### PR DESCRIPTION
## Description

- Sends trackIdToBitrates on iOS (temporarily)
- Fixed audio metadata

## Motivation and Context

- Fishjam requires trackId to bitrate mapping (even though it should not be required). This fix temporarily enables it on iOS.

## How has this been tested?

- Fixed microphone on iOS, Android and Web

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.