### PR TITLE
[FCE-1123] Update path to package.json in build.gradle

### DIFF
--- a/packages/react-native-client/android/build.gradle
+++ b/packages/react-native-client/android/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
-def inputFile = new File("$projectDir/../../../package.json")
+def inputFile = new File("$projectDir/../package.json")
 def packageJson = new JsonSlurper().parseText(inputFile.text)
 def packageVersion = packageJson["version"]
 


### PR DESCRIPTION
## Description

Current path might not work with all environments that package can be used.
So it is updated (to match iOS).

## Motivation and Context

Building app for android might not be possible without this patch.

## How has this been tested?

`mobile-client-test-app` has been used to verify this change (also Android version of `fishjam-chat` was build locally to confirm that fix works well with monorepo)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
