### PR TITLE
[FCE-1115] - Preview doesn't work on SDK 52

### DIFF
--- a/packages/react-native-client/ios/VideoPreviewView.swift
+++ b/packages/react-native-client/ios/VideoPreviewView.swift
@@ -44,6 +44,11 @@ class VideoPreviewView: ExpoView, LocalCameraTrackChangedListener {
             trySetLocalCameraTrack()
         }
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        videoView.frame = self.frame
+    }
 
     var videoLayout: String = "FILL" {
         didSet {

--- a/packages/react-native-client/ios/VideoPreviewView.swift
+++ b/packages/react-native-client/ios/VideoPreviewView.swift
@@ -44,7 +44,7 @@ class VideoPreviewView: ExpoView, LocalCameraTrackChangedListener {
             trySetLocalCameraTrack()
         }
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
         videoView.frame = self.frame

--- a/packages/react-native-client/ios/VideoRendererView.swift
+++ b/packages/react-native-client/ios/VideoRendererView.swift
@@ -25,6 +25,11 @@ class VideoRendererView: ExpoView, TrackUpdateListener {
             updateVideoTrack()
         }
     }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        videoView.frame = self.frame
+    }
 
     func updateVideoTrack() {
         DispatchQueue.main.async { [weak self] in

--- a/packages/react-native-client/ios/VideoRendererView.swift
+++ b/packages/react-native-client/ios/VideoRendererView.swift
@@ -25,7 +25,7 @@ class VideoRendererView: ExpoView, TrackUpdateListener {
             updateVideoTrack()
         }
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
         videoView.frame = self.frame


### PR DESCRIPTION
## Description

- Assign frame to subview when layoutSubviews is called

## Motivation and Context

Fabric probably caused this, however, I cannot locate the exact cause, so this is more of a solution to a cause rather than a proper fix. 

## How has this been tested?

Run preview and render screen on iOS.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
