### PR TITLE
FCE-1142: Calling prepareCamera twice on Android breaks preview

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClientModule.kt
@@ -166,8 +166,10 @@ class RNFishjamClientModule : Module() {
       }
 
       AsyncFunction("startCamera") Coroutine { config: CameraConfig ->
-        return@Coroutine withContext(Dispatchers.Main) {
-          return@withContext rnFishjamClient.startCamera(config)
+        mutex.withLock {
+          return@Coroutine withContext(Dispatchers.Main) {
+            return@withContext rnFishjamClient.startCamera(config)
+          }
         }
       }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -251,29 +251,29 @@ class RNFishjamClient: FishjamClientListener {
             self?.emitEndpoints()
         }
     }
-    
+
     private let startCameraLock = NSLock()
 
     func startCamera(config: CameraConfig) async throws -> Bool {
         #if targetEnvironment(simulator)
-        emit(
-            event: .warning(
-                message: "Camera is not supported on simulator."))
-        return false
+            emit(
+                event: .warning(
+                    message: "Camera is not supported on simulator."))
+            return false
         #endif
-        
+
         try ensureCreated()
 
         guard await PermissionUtils.requestCameraPermission() else {
             emit(event: .warning(message: "Camera permission not granted."))
             return false
         }
-        
+
         return try startCameraLock.withLock {
             guard !isCameraInitialized else {
                 return true
             }
-            
+
             let cameraTrack = try createCameraTrack(config: config)
             cameraTrack.captureDeviceChangedListener = self
             setCameraTrackState(cameraTrack, enabled: config.cameraEnabled)


### PR DESCRIPTION
## Description

- Added a lock when calling startCamera to prevent race conditions. 
- Also added a lock for iOS

## Motivation and Context

- If start camera was called too soon, it resulted in an undefined state. 

## How has this been tested?

- Tested calling prepareCamera multiple times on Android.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
