### PR TITLE
[FCE-1147] - Android can still stream even if app is killed

### DIFF
--- a/packages/react-native-client/plugin/src/withFishjamAndroid.ts
+++ b/packages/react-native-client/plugin/src/withFishjamAndroid.ts
@@ -12,6 +12,7 @@ const withFishjamForegroundService: ConfigPlugin = (config) =>
         'android:name':
           'io.fishjam.reactnative.foregroundService.FishjamForegroundService',
         'android:foregroundServiceType': 'camera|microphone|mediaProjection',
+        'android:stopWithTask': 'true',
       },
     };
 


### PR DESCRIPTION
## Description

- Fixed the script to close foregorund service on app close

## Motivation and Context

- There was a bug which allowed for stream to still be running after the app was closed.
- This can be further improved by using Headless JS but this requires another task. 

## How has this been tested?

- Reproduced the bug and then checked if it's not streaming anymore after the app is closed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
