### PR TITLE
FCE-1153: Fix frame to bounds

### DIFF
--- a/packages/react-native-client/ios/VideoPreviewView.swift
+++ b/packages/react-native-client/ios/VideoPreviewView.swift
@@ -47,7 +47,7 @@ class VideoPreviewView: ExpoView, LocalCameraTrackChangedListener {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        videoView.frame = self.frame
+        videoView.frame = bounds
     }
 
     var videoLayout: String = "FILL" {

--- a/packages/react-native-client/ios/VideoRendererView.swift
+++ b/packages/react-native-client/ios/VideoRendererView.swift
@@ -28,7 +28,7 @@ class VideoRendererView: ExpoView, TrackUpdateListener {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        videoView.frame = self.frame
+        videoView.frame = bounds
     }
 
     func updateVideoTrack() {


### PR DESCRIPTION
## Description

- Fixed frame assigned instead of bounds

## Motivation and Context

Stupid error. The frame also contains parent coordinates and we only need to assign the size...

## How has this been tested?

- Tested the case on iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
