### PR TITLE
FCE-1155: Fix Android view not reattached

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
@@ -26,15 +26,10 @@ class VideoPreviewView(
     super.setupTrack()
   }
 
-  override fun dispose() {
-    videoView.let { localVideoTrack?.removeRenderer(it) }
-    super.dispose()
-  }
-
   override fun onDetachedFromWindow() {
     RNFishjamClient.localCameraTracksChangedListenersManager.remove(this)
+    videoView.let { localVideoTrack?.removeRenderer(it) }
     super.onDetachedFromWindow()
-    dispose()
   }
 
   override fun onAttachedToWindow() {


### PR DESCRIPTION
## Description

- Removed view disposing on Android when detached from window.

## Motivation and Context

- I'm not sure what was the reason for this, but once the view is released it would have to be recreated to work again. There is also code in ViewModule that calls this when the view gets destroyed so there shouldn't be any leaks. 

## How has this been tested?

- Tested if view reinitializes when returning from a different tab.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
