### PR TITLE
FCE-1179: Emit a warning when codec not supported

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
@@ -102,4 +102,11 @@ interface FishjamClientListener : ReconnectionManagerListener {
   fun onBandwidthEstimationChanged(estimation: Long) {
     Timber.i("Bandwidth estimation changed: $estimation")
   }
+
+  /**
+   * Called after a SDP offer has been created.
+   *
+   * @param codecs - a list of strings with supported codecs by the device
+   */
+  fun onCodecsOffered(codecs: List<String>)
 }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -927,4 +927,13 @@ class RNFishjamClient(
       )
     )
   }
+
+  override fun onCodecsOffered(codecs: List<String>) {
+    // TODO: Remove when ex_webrtc adds support for both VP8 and H264
+    // Right now all rooms on Sandbox are created with H264. Android emulators
+    // usually won't support this, so let's inform users for now why stream is not working.
+    if (!codecs.contains("H264")) {
+      emitEvent(EmitableEvent.warning("H264 codec is not supported on your device. Video won't be sent/received."))
+    }
+  }
 }


### PR DESCRIPTION
## Description

- Added a warning on Android when H264 is not supported by device

## Motivation and Context

- Right now the stream just won't work which might confuse users.

## How has this been tested?

- Tested on Android emulator and a real device.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.