### PR TITLE
FCE-1179: Handle unsupported codecs in sdpAnswer

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -848,8 +848,6 @@ internal class FishjamClientInternal(
 
   override fun onLocalIceCandidate(candidate: IceCandidate) {
     coroutineScope.launch {
-      val hasInactiveTracks = candidate.sdp.contains("a=inactive")
-
       val splitSdp = candidate.sdp.split(" ")
       val ufrag = splitSdp[splitSdp.indexOf("ufrag") + 1]
       rtcEngineCommunication.localCandidate(

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -343,6 +343,10 @@ internal class FishjamClientInternal(
         }
       }
 
+      if (sdp.contains("a=inactive")) {
+        listener.onIncompatibleTracksDetected()
+      }
+
       commandsQueue.finishCommand(listOf(CommandName.ADD_TRACK, CommandName.REMOVE_TRACK))
     }
   }
@@ -844,6 +848,8 @@ internal class FishjamClientInternal(
 
   override fun onLocalIceCandidate(candidate: IceCandidate) {
     coroutineScope.launch {
+      val hasInactiveTracks = candidate.sdp.contains("a=inactive")
+
       val splitSdp = candidate.sdp.split(" ")
       val ufrag = splitSdp[splitSdp.indexOf("ufrag") + 1]
       rtcEngineCommunication.localCandidate(

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientListener.kt
@@ -102,4 +102,10 @@ interface FishjamClientListener : ReconnectionManagerListener {
   fun onBandwidthEstimationChanged(estimation: Long) {
     Timber.i("Bandwidth estimation changed: $estimation")
   }
+
+  /**
+   * Called when incompatible tracks are detected.
+   * This usually means that codecs are not supported by the receiver.
+   */
+  fun onIncompatibleTracksDetected()
 }

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -727,6 +727,11 @@ extension FishjamClientInternal: RTCEngineListener {
 
             }
         }
+        
+        if sdp.contains("a=inactive") {
+            listener.onIncompatibleTracksDetected()
+        }
+        
         commandsQueue.finishCommand(commandNames: [CommandName.ADD_TRACK, CommandName.REMOVE_TRACK])
     }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -727,11 +727,11 @@ extension FishjamClientInternal: RTCEngineListener {
 
             }
         }
-        
+
         if sdp.contains("a=inactive") {
             listener.onIncompatibleTracksDetected()
         }
-        
+
         commandsQueue.finishCommand(commandNames: [CommandName.ADD_TRACK, CommandName.REMOVE_TRACK])
     }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
@@ -79,5 +79,11 @@ public protocol FishjamClientListener: ReconnectionManagerListener {
      * by the server. It's measured in bits per second.
      */
     func onBandwidthEstimationChanged(estimation: Int)
+    
+    /**
+     * Called when incompatible tracks are detected.
+     * This usually means that codecs are not supported by the receiver.
+     */
+    func onIncompatibleTracksDetected()
 
 }

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientListener.swift
@@ -79,7 +79,7 @@ public protocol FishjamClientListener: ReconnectionManagerListener {
      * by the server. It's measured in bits per second.
      */
     func onBandwidthEstimationChanged(estimation: Int)
-    
+
     /**
      * Called when incompatible tracks are detected.
      * This usually means that codecs are not supported by the receiver.

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -927,4 +927,8 @@ class RNFishjamClient(
       )
     )
   }
+
+  override fun onIncompatibleTracksDetected() {
+    emitEvent(EmitableEvent.warning("Incompatible track detected. This usually means your device is missing codecs negotiated for the room."))
+  }
 }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -929,7 +929,7 @@ class RNFishjamClient(
   }
 
   override fun onIncompatibleTracksDetected() {
-    // TODO: Add proper url after docs are updated
+    // TODO: FCE-1215 Add proper url after docs are updated
     emitEvent(
       EmitableEvent.warning(
         "Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -929,6 +929,7 @@ class RNFishjamClient(
   }
 
   override fun onIncompatibleTracksDetected() {
-    emitEvent(EmitableEvent.warning("Incompatible track detected. This usually means your device is missing codecs negotiated for the room."))
+    // TODO: Add proper url after docs are updated
+    emitEvent(EmitableEvent.warning("Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."))
   }
 }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -930,6 +930,10 @@ class RNFishjamClient(
 
   override fun onIncompatibleTracksDetected() {
     // TODO: Add proper url after docs are updated
-    emitEvent(EmitableEvent.warning("Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."))
+    emitEvent(
+      EmitableEvent.warning(
+        "Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."
+      )
+    )
   }
 }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -919,7 +919,7 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func onIncompatibleTracksDetected() {
-        // TODO: Add proper url after docs are updated
+        // TODO: FCE-1215 Add proper url after docs are updated
         emit(
             event: .warning(
                 message:

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -917,6 +917,11 @@ class RNFishjamClient: FishjamClientListener {
     func onReconnectionRetriesLimitReached() {
         reconnectionStatus = .error
     }
+    
+    func onIncompatibleTracksDetected() {
+        // TODO: Add proper url after docs are updated
+        emit(event: .warning(message: "Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."))
+    }
 
 }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -917,10 +917,14 @@ class RNFishjamClient: FishjamClientListener {
     func onReconnectionRetriesLimitReached() {
         reconnectionStatus = .error
     }
-    
+
     func onIncompatibleTracksDetected() {
         // TODO: Add proper url after docs are updated
-        emit(event: .warning(message: "Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."))
+        emit(
+            event: .warning(
+                message:
+                    "Incompatible track detected. This usually means your device is missing codecs negotiated for the room. Visit https://docs.fishjam.io/category/react-native-integration for information."
+            ))
     }
 
 }


### PR DESCRIPTION
## Description

- Added a warning when an inactive track is present in an SDP answer. This usually means it was impossible to negotiate the track because of incompatible codecs. 

## Motivation and Context

- We want to inform users why video is not working.

## How has this been tested?

- Only tested on Android Emulator as iOS supports all available codecs in Fishjam.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
