### PR TITLE
FCE-1229: Fix camera track not stopped

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoRendererView.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoRendererView.kt
@@ -1,6 +1,7 @@
 package io.fishjam.reactnative
 
 import android.content.Context
+import com.fishjamcloud.client.media.LocalVideoTrack
 import com.fishjamcloud.client.media.VideoTrack
 import expo.modules.kotlin.AppContext
 import io.fishjam.reactnative.managers.TrackUpdateListener
@@ -47,7 +48,8 @@ class VideoRendererView(
 
   override fun dispose() {
     activeVideoTrack?.removeRenderer(videoView)
-    RNFishjamClient.trackUpdateListenersManager.add(this)
+    RNFishjamClient.trackUpdateListenersManager.remove(this)
+    (activeVideoTrack as? LocalVideoTrack)?.stop()
     super.dispose()
   }
 

--- a/packages/react-native-client/ios/VideoRendererView.swift
+++ b/packages/react-native-client/ios/VideoRendererView.swift
@@ -4,7 +4,7 @@ import FishjamCloudClient
 
 class VideoRendererView: ExpoView, TrackUpdateListener {
     var videoView: VideoView!
-    var cancellableEndpoints: Cancellable?
+    private var localVideoTrack: LocalCameraTrack?
 
     required init(appContext: AppContext? = nil) {
         super.init(appContext: appContext)
@@ -19,6 +19,7 @@ class VideoRendererView: ExpoView, TrackUpdateListener {
         if newSuperview == nil {
             videoView.removeFromSuperview()
             RNFishjamClient.tracksUpdateListenersManager.remove(self)
+            localVideoTrack?.stop()
         } else {
             addSubview(videoView)
             RNFishjamClient.tracksUpdateListenersManager.add(self)
@@ -38,6 +39,7 @@ class VideoRendererView: ExpoView, TrackUpdateListener {
                 guard let track = endpoint.tracks[self.trackId] as? VideoTrack else { continue }
                 if let track = track as? LocalCameraTrack {
                     self.mirrorVideo = track.isFrontCamera
+                    self.localVideoTrack = track
                 }
                 self.videoView.track = track
                 return

--- a/packages/react-native-client/ios/VideoRendererView.swift
+++ b/packages/react-native-client/ios/VideoRendererView.swift
@@ -4,7 +4,7 @@ import FishjamCloudClient
 
 class VideoRendererView: ExpoView, TrackUpdateListener {
     var videoView: VideoView!
-    private var localVideoTrack: LocalCameraTrack?
+    private weak var localVideoTrack: LocalCameraTrack?
 
     required init(appContext: AppContext? = nil) {
         super.init(appContext: appContext)


### PR DESCRIPTION
## Description

- Fixed local camera track not stopped
- Fixed a bug that listener was never removed

## Motivation and Context

- The bug was introduced here: https://github.com/fishjam-cloud/mobile-client-sdk/pull/330 
I missed the fact that it also handled disposing of the current capturer, therefor it had always camera on.

## How has this been tested?

- Tested od Android and iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
