### PR TITLE
FCE-1255: Add ability to trigger RN relase manually

### DIFF
--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -1,0 +1,22 @@
+# If for some reason release.yml fails for iOS or Android, but the spec is public, you can try to publish the React Native package manually.
+name: Publish React Native Package
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  publish-react-native-client:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - run: yarn
+      - run: yarn prepare
+      - name: Publish to NPM
+        run: yarn npm publish --access public
+        working-directory: packages/react-native-client
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,4 @@ jobs:
         working-directory: packages/android-client
   publish-react-native-client:
     needs: [publish-ios-client, publish-android-client]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - run: corepack enable
-      - run: yarn
-      - run: yarn prepare
-      - name: Publish to NPM
-        run: yarn npm publish --access public
-        working-directory: packages/react-native-client
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    uses: ./.github/workflows/publish-react-native.yml


### PR DESCRIPTION
## Description

- Created a reusable workflow so that if something fails we can still release RN package manually. 

## Motivation and Context

- Sometimes iOS or Android releases fail but the spec is published. This makes it impossible to release RN so we need a way to do it manually. 

## How has this been tested?

- Not possible before merge

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.