### PR TITLE
FCE-1328: Fix release action envs

### DIFF
--- a/.github/actions/publish-react-native-client/action.yml
+++ b/.github/actions/publish-react-native-client/action.yml
@@ -1,0 +1,22 @@
+name: "Publish React Native Client"
+description: "Publishes the React Native client package to NPM"
+inputs:
+  npm-token:
+    description: "NPM token for publishing"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - run: corepack enable
+      shell: bash
+    - run: yarn
+      shell: bash
+    - run: yarn prepare
+      shell: bash
+    - name: Publish to NPM
+      run: yarn npm publish --access public
+      working-directory: packages/react-native-client
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
+      shell: bash

--- a/.github/workflows/publish-react-native.yml
+++ b/.github/workflows/publish-react-native.yml
@@ -1,7 +1,6 @@
 # If for some reason release.yml fails for iOS or Android, but the spec is public, you can try to publish the React Native package manually.
 name: Publish React Native Package
 on:
-  workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -12,11 +11,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
-      - run: yarn
-      - run: yarn prepare
-      - name: Publish to NPM
-        run: yarn npm publish --access public
-        working-directory: packages/react-native-client
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish React Native Client
+        uses: ./.github/actions/publish-react-native-client
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,10 @@ jobs:
         working-directory: packages/android-client
   publish-react-native-client:
     needs: [publish-ios-client, publish-android-client]
-    uses: ./.github/workflows/publish-react-native.yml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish React Native Client
+        uses: ./.github/actions/publish-react-native-client
+        with:
+          npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description

- Transformed release rn to action
- npm token is now required and correctly passed from workflows

## Motivation and Context

- the workflow was failing when called from a different workflow because of missing npm token

## How has this been tested?

- not possible to test until next release

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
