### PR TITLE
FCE-1312: Fix Android preview stretched

### DIFF
--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -162,6 +162,7 @@ const styles = StyleSheet.create({
   cameraPreview: {
     flex: 6,
     margin: 24,
+    // TODO: This should no longer be needed after FCE-1181
     aspectRatio: 9 / 16,
     alignItems: 'center',
     borderRadius: 12,

--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -162,7 +162,7 @@ const styles = StyleSheet.create({
   cameraPreview: {
     flex: 6,
     margin: 24,
-    alignSelf: 'stretch',
+    aspectRatio: 9 / 16,
     alignItems: 'center',
     borderRadius: 12,
     borderWidth: 1,


### PR DESCRIPTION
## Description

- Added aspect ratio to preview

## Motivation and Context

- Preview was stretched and looked weird.  This is a temp fix as this issue should also resolve when https://linear.app/swmansion/issue/FCE-1181 is done.

## How has this been tested?

- Tested on android

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
