### PR TITLE
FCE-1305: Prevent adding of video tracks to audio-only rooms on mobile

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -14,6 +14,7 @@ import com.fishjamcloud.client.models.Endpoint
 import com.fishjamcloud.client.models.Metadata
 import com.fishjamcloud.client.models.Peer
 import com.fishjamcloud.client.models.RTCStats
+import com.fishjamcloud.client.models.RoomState
 import com.fishjamcloud.client.models.SimulcastConfig
 import com.fishjamcloud.client.models.TrackBandwidthLimit
 import com.fishjamcloud.client.models.TrackEncoding
@@ -61,6 +62,8 @@ internal class FishjamClientInternal(
   private var localEndpoint: Endpoint = Endpoint(id = "")
   private var prevTracks = mutableListOf<Track>()
   private var remoteEndpoints: MutableMap<String, Endpoint> = mutableMapOf()
+
+  private var roomState = RoomState()
 
   private val coroutineScope: CoroutineScope =
     ClosableCoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -138,6 +141,8 @@ internal class FishjamClientInternal(
           try {
             val peerMessage = PeerNotifications.PeerMessage.parseFrom(bytes.toByteArray())
             if (peerMessage.hasAuthenticated()) {
+              roomState.isAuthenticated = true
+              roomState.type = peerMessage.authenticated.roomType
               commandsQueue.finishCommand()
               join()
             } else if (peerMessage.hasServerMediaEvent()) {
@@ -220,6 +225,12 @@ internal class FishjamClientInternal(
     endpoints: Map<String, Server.MediaEvent.Endpoint>,
     iceServers: List<Server.MediaEvent.IceServer>
   ) {
+    if (roomState.type == PeerNotifications.PeerMessage.RoomType.ROOM_TYPE_AUDIO_ONLY && localEndpoint.hasVideoTracks()) {
+      Timber.e("Error while joining room. Room state is audio only but local track is video.")
+      listener.onJoinError(mapOf("reason" to "audio_only_room_with_video_track"))
+      return
+    }
+
     localEndpoint = localEndpoint.copy(id = endpointID)
     peerConnectionManager.setupIceServers(iceServers)
 
@@ -276,6 +287,7 @@ internal class FishjamClientInternal(
       rtcEngineCommunication.removeListener(this@FishjamClientInternal)
       webSocket?.close(1000, null)
       webSocket = null
+      roomState = RoomState()
       commandsQueue.clear()
       onLeave?.invoke()
     }
@@ -560,6 +572,11 @@ internal class FishjamClientInternal(
   }
 
   override fun onSendMediaEvent(event: fishjam.media_events.peer.Peer.MediaEvent) {
+    if (!roomState.isAuthenticated) {
+      Timber.e("Tried to send media event: $event before authentication")
+      return
+    }
+
     val mediaEvent =
       PeerNotifications.PeerMessage
         .newBuilder()

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/Endpoint.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/Endpoint.kt
@@ -1,6 +1,7 @@
 package com.fishjamcloud.client.models
 
 import com.fishjamcloud.client.media.Track
+import com.fishjamcloud.client.media.VideoTrack
 
 data class Endpoint(
   val id: String,
@@ -17,6 +18,10 @@ data class Endpoint(
     val tracks = tracks.toMutableMap()
     tracks.remove(trackId)
     return this.copy(tracks = tracks)
+  }
+
+  internal fun hasVideoTracks(): Boolean {
+    return tracks.values.any { it is VideoTrack }
   }
 }
 

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/Endpoint.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/Endpoint.kt
@@ -20,9 +20,7 @@ data class Endpoint(
     return this.copy(tracks = tracks)
   }
 
-  internal fun hasVideoTracks(): Boolean {
-    return tracks.values.any { it is VideoTrack }
-  }
+  internal fun hasVideoTracks(): Boolean = tracks.values.any { it is VideoTrack }
 }
 
 typealias Peer = Endpoint

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/RoomState.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/models/RoomState.kt
@@ -1,0 +1,7 @@
+package com.fishjamcloud.client.models
+import fishjam.PeerNotifications
+
+class RoomState {
+  var isAuthenticated = false
+  var type = PeerNotifications.PeerMessage.RoomType.ROOM_TYPE_UNSPECIFIED
+}

--- a/packages/android-client/FishjamClient/src/main/java/fishjam/PeerNotifications.java
+++ b/packages/android-client/FishjamClient/src/main/java/fishjam/PeerNotifications.java
@@ -182,6 +182,10 @@ public final class PeerNotifications {
        * <code>ROOM_TYPE_AUDIO_ONLY = 2;</code>
        */
       ROOM_TYPE_AUDIO_ONLY(2),
+      /**
+       * <code>ROOM_TYPE_BROADCASTER = 3;</code>
+       */
+      ROOM_TYPE_BROADCASTER(3),
       UNRECOGNIZED(-1),
       ;
 
@@ -206,6 +210,10 @@ public final class PeerNotifications {
        * <code>ROOM_TYPE_AUDIO_ONLY = 2;</code>
        */
       public static final int ROOM_TYPE_AUDIO_ONLY_VALUE = 2;
+      /**
+       * <code>ROOM_TYPE_BROADCASTER = 3;</code>
+       */
+      public static final int ROOM_TYPE_BROADCASTER_VALUE = 3;
 
 
       public final int getNumber() {
@@ -235,6 +243,7 @@ public final class PeerNotifications {
           case 0: return ROOM_TYPE_UNSPECIFIED;
           case 1: return ROOM_TYPE_FULL_FEATURE;
           case 2: return ROOM_TYPE_AUDIO_ONLY;
+          case 3: return ROOM_TYPE_BROADCASTER;
           default: return null;
         }
       }
@@ -4155,7 +4164,7 @@ public final class PeerNotifications {
       "\n fishjam/peer_notifications.proto\022\007fish" +
       "jam\032$fishjam/media_events/peer/peer.prot" +
       "o\032(fishjam/media_events/server/server.pr" +
-      "oto\"\241\005\n\013PeerMessage\022;\n\rauthenticated\030\001 \001" +
+      "oto\"\274\005\n\013PeerMessage\022;\n\rauthenticated\030\001 \001" +
       "(\0132\".fishjam.PeerMessage.AuthenticatedH\000" +
       "\0228\n\014auth_request\030\002 \001(\0132 .fishjam.PeerMes" +
       "sage.AuthRequestH\000\0226\n\013media_event\030\003 \001(\0132" +
@@ -4169,10 +4178,10 @@ public final class PeerNotifications {
       "jam.PeerMessage.RoomType\0321\n\013AuthRequest\022" +
       "\r\n\005token\030\001 \001(\t\022\023\n\013sdk_version\030\002 \001(\t\032\036\n\016R" +
       "TCStatsReport\022\014\n\004data\030\001 \001(\t\032\032\n\nMediaEven" +
-      "t\022\014\n\004data\030\001 \001(\t\"[\n\010RoomType\022\031\n\025ROOM_TYPE" +
+      "t\022\014\n\004data\030\001 \001(\t\"v\n\010RoomType\022\031\n\025ROOM_TYPE" +
       "_UNSPECIFIED\020\000\022\032\n\026ROOM_TYPE_FULL_FEATURE" +
-      "\020\001\022\030\n\024ROOM_TYPE_AUDIO_ONLY\020\002B\t\n\007contentb" +
-      "\006proto3"
+      "\020\001\022\030\n\024ROOM_TYPE_AUDIO_ONLY\020\002\022\031\n\025ROOM_TYP" +
+      "E_BROADCASTER\020\003B\t\n\007contentb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -476,16 +476,16 @@ class FishjamClientInternal {
             prevTracks = []
         }
     }
-  
-  func add(track: Track) {
-    if roomState.type == .audioOnly && track is VideoTrack {
-      sdkLogger.error(
-          "\(_loggerPrefix) Cannot add track to an audio_only room")
-      listener.onJoinError(metadata: ["reason": "audio_only_room_with_video_track"])
-      return
+
+    func add(track: Track) {
+        if roomState.type == .audioOnly && track is VideoTrack {
+            sdkLogger.error(
+                "\(_loggerPrefix) Cannot add track to an audio_only room")
+            listener.onJoinError(metadata: ["reason": "audio_only_room_with_video_track"])
+            return
+        }
+        peerConnectionManager.addTrack(track: track)
     }
-    peerConnectionManager.addTrack(track: track)
-  }
 }
 
 extension FishjamClientInternal: WebSocketDelegate {

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -614,11 +614,12 @@ extension FishjamClientInternal: RTCEngineListener {
     ) {
 
         if roomState.type == .audioOnly && localEndpoint.hasVideoTracks {
-          sdkLogger.error("\(_loggerPrefix) Error while joining room. Room state is audio only but local track is video.")
-          listener.onJoinError(metadata: ["reason": "audio_only_room_with_video_track"])
-          return
+            sdkLogger.error(
+                "\(_loggerPrefix) Error while joining room. Room state is audio only but local track is video.")
+            listener.onJoinError(metadata: ["reason": "audio_only_room_with_video_track"])
+            return
         }
-      
+
         localEndpoint = localEndpoint.copyWith(id: endpointId)
         peerConnectionManager.setupIceServers(iceServers: iceServers)
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -129,7 +129,7 @@ class FishjamClientInternal {
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
                 self.localEndpoint = self.localEndpoint.addOrReplaceTrack(videoTrack)
-                self.peerConnectionManager.addTrack(track: videoTrack)
+                self.add(track: videoTrack)
                 if self.commandsQueue.clientState == .CONNECTED || self.commandsQueue.clientState == .JOINED {
                     self.rtcEngineCommunication.renegotiateTracks()
                 } else {
@@ -154,7 +154,7 @@ class FishjamClientInternal {
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
                 self.localEndpoint = self.localEndpoint.addOrReplaceTrack(audioTrack)
-                self.peerConnectionManager.addTrack(track: audioTrack)
+                self.add(track: audioTrack)
                 if self.commandsQueue.clientState == .CONNECTED || self.commandsQueue.clientState == .JOINED {
                     self.rtcEngineCommunication.renegotiateTracks()
                 } else {
@@ -185,7 +185,7 @@ class FishjamClientInternal {
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) { [weak self] in
                 guard let self else { return }
                 localEndpoint = localEndpoint.addOrReplaceTrack(track)
-                peerConnectionManager.addTrack(track: track)
+                add(track: track)
                 if commandsQueue.clientState == .CONNECTED || self.commandsQueue.clientState == .JOINED {
                     rtcEngineCommunication.renegotiateTracks()
                 } else {
@@ -227,7 +227,7 @@ class FishjamClientInternal {
                     Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) { [weak self] in
                         guard let self else { return }
                         localEndpoint = localEndpoint.addOrReplaceTrack(track)
-                        peerConnectionManager.addTrack(track: track)
+                        add(track: track)
                         if commandsQueue.clientState == .CONNECTED || self.commandsQueue.clientState == .JOINED {
                             rtcEngineCommunication.renegotiateTracks()
                         } else {
@@ -269,7 +269,7 @@ class FishjamClientInternal {
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
                 self.localEndpoint = self.localEndpoint.addOrReplaceTrack(videoTrack)
-                self.peerConnectionManager.addTrack(track: videoTrack)
+                self.add(track: videoTrack)
                 if self.commandsQueue.clientState == .CONNECTED || self.commandsQueue.clientState == .JOINED {
                     self.rtcEngineCommunication.renegotiateTracks()
                 } else {
@@ -476,6 +476,16 @@ class FishjamClientInternal {
             prevTracks = []
         }
     }
+  
+  func add(track: Track) {
+    if roomState.type == .audioOnly && track is VideoTrack {
+      sdkLogger.error(
+          "\(_loggerPrefix) Cannot add track to an audio_only room")
+      listener.onJoinError(metadata: ["reason": "audio_only_room_with_video_track"])
+      return
+    }
+    peerConnectionManager.addTrack(track: track)
+  }
 }
 
 extension FishjamClientInternal: WebSocketDelegate {

--- a/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
@@ -30,4 +30,8 @@ public struct Endpoint {
         newTracks.removeValue(forKey: track.id)
         return copyWith(tracks: newTracks)
     }
+  
+    var hasVideoTracks: Bool {
+      tracks.values.contains(where: { $0 is VideoTrack })
+    }
 }

--- a/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
@@ -30,8 +30,8 @@ public struct Endpoint {
         newTracks.removeValue(forKey: track.id)
         return copyWith(tracks: newTracks)
     }
-  
+
     var hasVideoTracks: Bool {
-      tracks.values.contains(where: { $0 is VideoTrack })
+        tracks.values.contains(where: { $0 is VideoTrack })
     }
 }

--- a/packages/ios-client/Sources/FishjamClient/models/RoomState.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/RoomState.swift
@@ -1,4 +1,4 @@
 struct RoomState {
-  var isAuthenticated = false
-  var type = Fishjam_PeerMessage.RoomType.unspecified
+    var isAuthenticated = false
+    var type = Fishjam_PeerMessage.RoomType.unspecified
 }

--- a/packages/ios-client/Sources/FishjamClient/models/RoomState.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/RoomState.swift
@@ -1,0 +1,4 @@
+struct RoomState {
+  var isAuthenticated = false
+  var type = Fishjam_PeerMessage.RoomType.unspecified
+}

--- a/packages/ios-client/Sources/FishjamClient/models/TrackTypeError.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/TrackTypeError.swift
@@ -1,0 +1,5 @@
+struct TrackTypeError: Error, CustomDebugStringConvertible {
+  var debugDescription: String {
+    return "Attempted to add video track to audio-only room. Please refer to the docs at https://docs.fishjam.io/audio-calls"
+  }
+}

--- a/packages/ios-client/Sources/FishjamClient/models/TrackTypeError.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/TrackTypeError.swift
@@ -1,5 +1,6 @@
 struct TrackTypeError: Error, CustomDebugStringConvertible {
-  var debugDescription: String {
-    return "Attempted to add video track to audio-only room. Please refer to the docs at https://docs.fishjam.io/audio-calls"
-  }
+    var debugDescription: String {
+        return
+            "Attempted to add video track to audio-only room. Please refer to the docs at https://docs.fishjam.io/audio-calls"
+    }
 }

--- a/packages/ios-client/Sources/FishjamClient/protos/fishjam/peer_notifications.pb.swift
+++ b/packages/ios-client/Sources/FishjamClient/protos/fishjam/peer_notifications.pb.swift
@@ -128,6 +128,7 @@ public struct Fishjam_PeerMessage {
     case unspecified // = 0
     case fullFeature // = 1
     case audioOnly // = 2
+    case broadcaster // = 3
     case UNRECOGNIZED(Int)
 
     public init() {
@@ -139,6 +140,7 @@ public struct Fishjam_PeerMessage {
       case 0: self = .unspecified
       case 1: self = .fullFeature
       case 2: self = .audioOnly
+      case 3: self = .broadcaster
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
@@ -148,6 +150,7 @@ public struct Fishjam_PeerMessage {
       case .unspecified: return 0
       case .fullFeature: return 1
       case .audioOnly: return 2
+      case .broadcaster: return 3
       case .UNRECOGNIZED(let i): return i
       }
     }
@@ -220,6 +223,7 @@ extension Fishjam_PeerMessage.RoomType: CaseIterable {
     .unspecified,
     .fullFeature,
     .audioOnly,
+    .broadcaster,
   ]
 }
 
@@ -386,6 +390,7 @@ extension Fishjam_PeerMessage.RoomType: SwiftProtobuf._ProtoNameProviding {
     0: .same(proto: "ROOM_TYPE_UNSPECIFIED"),
     1: .same(proto: "ROOM_TYPE_FULL_FEATURE"),
     2: .same(proto: "ROOM_TYPE_AUDIO_ONLY"),
+    3: .same(proto: "ROOM_TYPE_BROADCASTER"),
   ]
 }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -788,7 +788,7 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func onJoinError(metadata: Any) {
-      let reason = (metadata as? Dictionary<String, Any>)?["reason"] as? String ?? "Unknown error"
+        let reason = (metadata as? [String: Any])?["reason"] as? String ?? "Unknown error"
         connectPromise?.reject("E_MEMBRANE_CONNECT", "Failed to join room, reason: \(reason)")
         connectPromise = nil
     }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -788,7 +788,8 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func onJoinError(metadata: Any) {
-        connectPromise?.reject("E_MEMBRANE_CONNECT", "Failed to join room")
+      let reason = (metadata as? Dictionary<String, Any>)?["reason"] as? String ?? "Unknown error"
+        connectPromise?.reject("E_MEMBRANE_CONNECT", "Failed to join room, reason: \(reason)")
         connectPromise = nil
     }
 


### PR DESCRIPTION
## Description

- Blocked ability to join room with video tracks added
- Updated protos

## Motivation and Context

- This change was required to prevent errors when trying to add video tracks to audio only rooms

## How has this been tested?

Run and tested on iOS and Android

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.