### PR TITLE
FCE: 1360: Enable lineBreakBeforeEachArgument in Swift

### DIFF
--- a/packages/ios-client/Sources/FishjamClient/CustomSourceManager.swift
+++ b/packages/ios-client/Sources/FishjamClient/CustomSourceManager.swift
@@ -6,7 +6,10 @@ class CustomSourceManager {
     func add(source: CustomSource, withTrackId trackId: String, forRTCVideoSource videoSource: RTCVideoSource) {
         sources.append(
             CustomSourceRTCVideoCapturerAdapter(
-                trackId: trackId, customSource: source, rtcVideoSource: videoSource)
+                trackId: trackId,
+                customSource: source,
+                rtcVideoSource: videoSource
+            )
         )
     }
 

--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -96,7 +96,10 @@ public class FishjamClient {
         captureDeviceName: String? = nil
     ) -> LocalCameraTrack {
         return client.createCameraTrack(
-            videoParameters: videoParameters, metadata: metadata, captureDeviceName: captureDeviceName)
+            videoParameters: videoParameters,
+            metadata: metadata,
+            captureDeviceName: captureDeviceName
+        )
     }
 
     /**

--- a/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClientInternal.swift
@@ -41,7 +41,9 @@ class FishjamClientInternal {
         self.rtcEngineCommunication = RTCEngineCommunication(listeners: [])
         self.peerConnectionFactoryWrapper = PeerConnectionFactoryWrapper(encoder: Encoder.DEFAULT)
         self.peerConnectionManager = PeerConnectionManager(
-            config: RTCConfiguration(), peerConnectionFactory: peerConnectionFactoryWrapper)
+            config: RTCConfiguration(),
+            peerConnectionFactory: peerConnectionFactoryWrapper
+        )
     }
 
     private func getTrack(trackId: String) -> Track? {
@@ -74,7 +76,10 @@ class FishjamClientInternal {
         peerConnectionManager.addListener(self)
         rtcEngineCommunication.addListener(self)
         self.reconnectionManager = ReconnectionManager(
-            reconnectConfig: config.reconnectConfig, connect: { self.reconnect(config: config) }, listener: listener)
+            reconnectConfig: config.reconnectConfig,
+            connect: { self.reconnect(config: config) },
+            listener: listener
+        )
         setupWebsocket(config: config)
     }
 
@@ -97,7 +102,8 @@ class FishjamClientInternal {
         commandsQueue.addCommand(
             Command(commandName: .JOIN, clientStateAfterCommand: .JOINED) {
                 self.rtcEngineCommunication.connect(metadata: self.config?.peerMetadata ?? [:].toMetadata())
-            })
+            }
+        )
     }
 
     func leave(onLeave: (() -> Void)? = nil) {
@@ -120,11 +126,18 @@ class FishjamClientInternal {
         let videoSource = peerConnectionFactoryWrapper.createVideoSource()
         let webrtcTrack = peerConnectionFactoryWrapper.createVideoTrack(source: videoSource)
         let videoCapturer = CameraCapturer(
-            videoParameters: videoParameters, delegate: videoSource, deviceId: captureDeviceName)
-        let videoTrack = LocalCameraTrack(
-            mediaTrack: webrtcTrack, videoSource: videoSource, endpointId: localEndpoint.id, metadata: metadata,
             videoParameters: videoParameters,
-            capturer: videoCapturer)
+            delegate: videoSource,
+            deviceId: captureDeviceName
+        )
+        let videoTrack = LocalCameraTrack(
+            mediaTrack: webrtcTrack,
+            videoSource: videoSource,
+            endpointId: localEndpoint.id,
+            metadata: metadata,
+            videoParameters: videoParameters,
+            capturer: videoCapturer
+        )
         videoTrack.start()
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
@@ -135,7 +148,8 @@ class FishjamClientInternal {
                 } else {
                     self.commandsQueue.finishCommand(commandName: .ADD_TRACK)
                 }
-            })
+            }
+        )
         do {
             try awaitPromise(promise)
         } catch {
@@ -149,7 +163,11 @@ class FishjamClientInternal {
         let webrtcTrack = peerConnectionFactoryWrapper.createAudioTrack(source: audioSource)
         webrtcTrack.isEnabled = true
         let audioTrack = LocalAudioTrack(
-            mediaTrack: webrtcTrack, audioSource: audioSource, endpointId: localEndpoint.id, metadata: metadata)
+            mediaTrack: webrtcTrack,
+            audioSource: audioSource,
+            endpointId: localEndpoint.id,
+            metadata: metadata
+        )
         audioTrack.start()
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
@@ -160,7 +178,8 @@ class FishjamClientInternal {
                 } else {
                     self.commandsQueue.finishCommand(commandName: .ADD_TRACK)
                 }
-            })
+            }
+        )
 
         do {
             try awaitPromise(promise)
@@ -191,7 +210,8 @@ class FishjamClientInternal {
                 } else {
                     commandsQueue.finishCommand(commandName: .ADD_TRACK)
                 }
-            })
+            }
+        )
 
         try awaitPromise(promise)
 
@@ -207,7 +227,9 @@ class FishjamClientInternal {
     }
 
     public func prepareForBroadcastScreenSharing(
-        appGroup: String, videoParameters: VideoParameters, metadata: Metadata,
+        appGroup: String,
+        videoParameters: VideoParameters,
+        metadata: Metadata,
         canStart: @escaping () -> Bool,
         onStart: @escaping () -> Void,
         onStop: @escaping () -> Void
@@ -220,9 +242,13 @@ class FishjamClientInternal {
                 guard canStart() else { return }
                 let webrtcTrack = peerConnectionFactoryWrapper.createVideoTrack(source: videoSource)
                 let track = LocalBroadcastScreenShareTrack(
-                    mediaTrack: webrtcTrack, videoSource: videoSource, endpointId: localEndpoint.id, metadata: metadata,
+                    mediaTrack: webrtcTrack,
+                    videoSource: videoSource,
+                    endpointId: localEndpoint.id,
+                    metadata: metadata,
                     appGroup: appGroup,
-                    videoParameters: videoParameters)
+                    videoParameters: videoParameters
+                )
                 let promise = commandsQueue.addCommand(
                     Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) { [weak self] in
                         guard let self else { return }
@@ -234,7 +260,8 @@ class FishjamClientInternal {
                             commandsQueue.finishCommand(commandName: .ADD_TRACK)
                         }
                         onStart()
-                    })
+                    }
+                )
                 do {
                     try awaitPromise(promise)
                     listener.onTrackAdded(track: track)
@@ -248,10 +275,14 @@ class FishjamClientInternal {
                 removeTrack(trackId: track.id)
                 listener.onTrackRemoved(track: track)
                 onStop()
-            })
+            }
+        )
 
         broadcastScreenShareCapturer = BroadcastScreenShareCapturer(
-            videoSource, appGroup: appGroup, videoParameters: videoParameters)
+            videoSource,
+            appGroup: appGroup,
+            videoParameters: videoParameters
+        )
         broadcastScreenShareCapturer?.capturerDelegate = broadcastScreenShareReceiver
         broadcastScreenShareCapturer?.startListening()
     }
@@ -263,8 +294,13 @@ class FishjamClientInternal {
         let webrtcTrack = peerConnectionFactoryWrapper.createVideoTrack(source: videoSource)
         let videoCapturer = AppScreenShareCapturer(videoSource)
         let videoTrack = LocalAppScreenShareTrack(
-            mediaTrack: webrtcTrack, videoSource: videoSource, endpointId: localEndpoint.id, metadata: metadata,
-            videoParameters: videoParameters, capturer: videoCapturer)
+            mediaTrack: webrtcTrack,
+            videoSource: videoSource,
+            endpointId: localEndpoint.id,
+            metadata: metadata,
+            videoParameters: videoParameters,
+            capturer: videoCapturer
+        )
         videoTrack.start()
         let promise = commandsQueue.addCommand(
             Command(commandName: .ADD_TRACK, clientStateAfterCommand: nil) {
@@ -275,7 +311,8 @@ class FishjamClientInternal {
                 } else {
                     self.commandsQueue.finishCommand(commandName: .ADD_TRACK)
                 }
-            })
+            }
+        )
         do {
             try awaitPromise(promise)
         } catch {
@@ -298,7 +335,8 @@ class FishjamClientInternal {
                 }
 
                 self.listener.onTrackRemoved(track: track)
-            })
+            }
+        )
         do {
             try awaitPromise(promise)
         } catch {}
@@ -534,13 +572,21 @@ extension FishjamClientInternal: PeerConnectionListener {
         switch webrtcTrack {
         case let videoTrack as RTCVideoTrack:
             track = RemoteVideoTrack(
-                mediaTrack: videoTrack, endpointId: endpointId, rtcEngineId: rtcEngineId, metadata: metadata,
-                id: trackId)
+                mediaTrack: videoTrack,
+                endpointId: endpointId,
+                rtcEngineId: rtcEngineId,
+                metadata: metadata,
+                id: trackId
+            )
 
         case let audioTrack as RTCAudioTrack:
             track = RemoteAudioTrack(
-                audioTrack: audioTrack, endpointId: endpointId, rtcEngineId: rtcEngineId, metadata: metadata,
-                id: trackId)
+                audioTrack: audioTrack,
+                endpointId: endpointId,
+                rtcEngineId: rtcEngineId,
+                metadata: metadata,
+                id: trackId
+            )
 
         default:
             sdkLogger.error("Invalid type of incoming track")
@@ -558,8 +604,11 @@ extension FishjamClientInternal: PeerConnectionListener {
         }
         let ufrag = String(splitSdp[ufragIndex + 1])
         rtcEngineCommunication.localCandidate(
-            sdp: candidate.sdp, sdpMLineIndex: candidate.sdpMLineIndex, sdpMid: Int32(candidate.sdpMid ?? "0") ?? 0,
-            usernameFragment: ufrag)
+            sdp: candidate.sdp,
+            sdpMLineIndex: candidate.sdpMLineIndex,
+            sdpMid: Int32(candidate.sdpMid ?? "0") ?? 0,
+            usernameFragment: ufrag
+        )
     }
 }
 
@@ -608,7 +657,8 @@ extension FishjamClientInternal: RTCEngineListener {
     }
 
     func onConnected(
-        endpointId: String, endpointIdToEndpoint: [String: Fishjam_MediaEvents_Server_MediaEvent.Endpoint],
+        endpointId: String,
+        endpointIdToEndpoint: [String: Fishjam_MediaEvents_Server_MediaEvent.Endpoint],
         iceServers: [Fishjam_MediaEvents_Server_MediaEvent.IceServer]
     ) {
         localEndpoint = localEndpoint.copyWith(id: endpointId)
@@ -620,7 +670,8 @@ extension FishjamClientInternal: RTCEngineListener {
             } else {
                 var endpoint = Endpoint(
                     id: eventEndpointId,
-                    metadata: (try? AnyJson(from: eventEndpoint.metadataJson)) ?? Metadata())
+                    metadata: (try? AnyJson(from: eventEndpoint.metadataJson)) ?? Metadata()
+                )
 
                 for (trackId, track) in eventEndpoint.trackIDToTrack {
                     let track = Track(
@@ -647,7 +698,8 @@ extension FishjamClientInternal: RTCEngineListener {
                 } else {
                     self.commandsQueue.finishCommand(commandName: .ADD_TRACK)
                 }
-            })
+            }
+        )
         do {
             try awaitPromise(promise)
         } catch {

--- a/packages/ios-client/Sources/FishjamClient/ipc/IPC.swift
+++ b/packages/ios-client/Sources/FishjamClient/ipc/IPC.swift
@@ -14,7 +14,8 @@ extension CFMessagePort {
             self as Any,
             &CFMessagePort.selfObjectHandle,
             obj,
-            objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
     }
 }
 
@@ -68,7 +69,8 @@ public class IPCServer: IPC {
         }
 
         port = CFMessagePortCreateLocal(
-            nil, name as CFString,
+            nil,
+            name as CFString,
             {
                 (port: CFMessagePort?, id: Int32, data: CFData?, _: UnsafeMutableRawPointer?) -> Unmanaged<CFData>? in
                 guard let selfObj = port?.associatedSelf() as? IPCServer,
@@ -79,7 +81,10 @@ public class IPCServer: IPC {
 
                 selfObj.onReceive?(selfObj, id, data)
                 return nil
-            }, nil, nil)
+            },
+            nil,
+            nil
+        )
 
         if let port = port {
             port.associateSelf(self)

--- a/packages/ios-client/Sources/FishjamClient/media/BroadcastSampleSource.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/BroadcastSampleSource.swift
@@ -101,7 +101,10 @@ public class BroadcastSampleSource {
             // Check rotation tags. Extensions see these tags, but `RPScreenRecorder` does not appear to set them.
             // On iOS 12.0 and 13.0 rotation tags (other than up) are set by extensions.
             if let sampleOrientation = CMGetAttachment(
-                sampleBuffer, key: RPVideoSampleOrientationKey as CFString, attachmentModeOut: nil),
+                sampleBuffer,
+                key: RPVideoSampleOrientationKey as CFString,
+                attachmentModeOut: nil
+            ),
                 let coreSampleOrientation = sampleOrientation.uint32Value
             {
                 rotation = CGImagePropertyOrientation(rawValue: coreSampleOrientation)?.toRTCRotation()

--- a/packages/ios-client/Sources/FishjamClient/media/Capturers/AppScreenShareCapturer.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Capturers/AppScreenShareCapturer.swift
@@ -41,7 +41,10 @@ class AppScreenShareCapturer: RTCVideoCapturer, VideoCapturer {
             Int64(CMTimeGetSeconds(CMSampleBufferGetPresentationTimeStamp(buffer))) * Int64(NSEC_PER_SEC)
 
         let videoFrame = RTCVideoFrame(
-            buffer: rtcPixelBuffer, rotation: RTCVideoRotation._0, timeStampNs: timeStampNs)
+            buffer: rtcPixelBuffer,
+            rotation: RTCVideoRotation._0,
+            timeStampNs: timeStampNs
+        )
 
         let delegate = source as RTCVideoCapturerDelegate
 
@@ -57,7 +60,8 @@ class AppScreenShareCapturer: RTCVideoCapturer, VideoCapturer {
             },
             completionHandler: { error in
                 sdkLogger.error("Encountered error while capturing screen: \(error?.localizedDescription ?? "")")
-            })
+            }
+        )
     }
 
     func stopCapture() {

--- a/packages/ios-client/Sources/FishjamClient/media/Capturers/BroadcastScreenShareCapturer.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Capturers/BroadcastScreenShareCapturer.swift
@@ -30,7 +30,13 @@ extension CVPixelBuffer {
             var pixelBuffer: CVPixelBuffer!
 
             let result = CVPixelBufferCreate(
-                kCFAllocatorDefault, width, height, pixelFormat, nil, &pixelBuffer)
+                kCFAllocatorDefault,
+                width,
+                height,
+                pixelFormat,
+                nil,
+                &pixelBuffer
+            )
             guard result == kCVReturnSuccess else { fatalError() }
 
             CVPixelBufferLockBaseAddress(pixelBuffer, [])
@@ -96,7 +102,9 @@ class BroadcastScreenShareCapturer: RTCVideoCapturer {
         - delegate: A delegate that will receive notifications about the sceeen capture events such as started/stopped or paused
      */
     init(
-        _ source: RTCVideoSource, appGroup: String, videoParameters: VideoParameters,
+        _ source: RTCVideoSource,
+        appGroup: String,
+        videoParameters: VideoParameters,
         delegate: BroadcastScreenShareReceiverDelegate? = nil
     ) {
         self.source = source
@@ -172,14 +180,21 @@ class BroadcastScreenShareCapturer: RTCVideoCapturer {
 
                 let dimensions = downscaleResolution(
                     from: Dimensions(width: Int32(video.width), height: Int32(video.height)),
-                    to: videoParameters.dimensions)
+                    to: videoParameters.dimensions
+                )
 
                 self.source.adaptOutputFormat(
-                    toWidth: dimensions.width, height: dimensions.height, fps: Int32(videoParameters.maxFps))
+                    toWidth: dimensions.width,
+                    height: dimensions.height,
+                    fps: Int32(videoParameters.maxFps)
+                )
 
                 let pixelBuffer = CVPixelBuffer.from(
-                    sample.buffer, width: Int(video.width), height: Int(video.height),
-                    pixelFormat: video.format)
+                    sample.buffer,
+                    width: Int(video.width),
+                    height: Int(video.height),
+                    pixelFormat: video.format
+                )
                 let height = Int32(CVPixelBufferGetHeight(pixelBuffer))
                 let width = Int32(CVPixelBufferGetWidth(pixelBuffer))
 
@@ -190,7 +205,8 @@ class BroadcastScreenShareCapturer: RTCVideoCapturer {
                     cropWidth: width,
                     cropHeight: height,
                     cropX: 0,
-                    cropY: 0)
+                    cropY: 0
+                )
 
                 var rotation: RTCVideoRotation = ._0
 
@@ -209,7 +225,10 @@ class BroadcastScreenShareCapturer: RTCVideoCapturer {
                 // the I420 somehow does so keep it in that format as long as it works
                 let buffer = rtcBuffer.toI420()
                 let videoFrame = RTCVideoFrame(
-                    buffer: buffer, rotation: rotation, timeStampNs: sample.timestamp)
+                    buffer: buffer,
+                    rotation: rotation,
+                    timeStampNs: sample.timestamp
+                )
 
                 let delegate = source as RTCVideoCapturerDelegate
 

--- a/packages/ios-client/Sources/FishjamClient/media/Capturers/FishjamCustomSource.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Capturers/FishjamCustomSource.swift
@@ -18,7 +18,9 @@ class CustomSourceRTCVideoCapturerAdapter: RTCVideoCapturer, CustomSourceDelegat
     let customSource: CustomSource
 
     init(
-        trackId: String, customSource: CustomSource, rtcVideoSource: RTCVideoSource
+        trackId: String,
+        customSource: CustomSource,
+        rtcVideoSource: RTCVideoSource
     ) {
         self.trackId = trackId
         self.rtcVideoSource = rtcVideoSource
@@ -45,13 +47,17 @@ class CustomSourceRTCVideoCapturerAdapter: RTCVideoCapturer, CustomSourceDelegat
             cropWidth: width,
             cropHeight: height,
             cropX: 0,
-            cropY: 0)
+            cropY: 0
+        )
 
         let rotation = RTCVideoRotation._0
 
         let buffer = rtcBuffer.toI420()
         let videoFrame = RTCVideoFrame(
-            buffer: buffer, rotation: rotation, timeStampNs: sampleBuffer.presentationTimeStamp.value)
+            buffer: buffer,
+            rotation: rotation,
+            timeStampNs: sampleBuffer.presentationTimeStamp.value
+        )
 
         let delegate = rtcVideoSource as RTCVideoCapturerDelegate
 

--- a/packages/ios-client/Sources/FishjamClient/media/SoundDetection.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/SoundDetection.swift
@@ -75,8 +75,11 @@ public class SoundDetection: ObservableObject {
             engine.connect(inputNode, to: mixerNode, format: inputFormat)
             let mainMixerNode = engine.mainMixerNode
             let mixerFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32, sampleRate: inputFormat.sampleRate, channels: 1,
-                interleaved: false)
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: inputFormat.sampleRate,
+                channels: 1,
+                interleaved: false
+            )
             engine.connect(mixerNode, to: mainMixerNode, format: mixerFormat)
         }
     }
@@ -94,7 +97,9 @@ public class SoundDetection: ObservableObject {
             let format = tapNode.outputFormat(forBus: 0)
 
             tapNode.installTap(
-                onBus: 0, bufferSize: 4096, format: format,
+                onBus: 0,
+                bufferSize: 4096,
+                format: format,
                 block: {
                     (buffer, time) in
                     do {
@@ -102,7 +107,8 @@ public class SoundDetection: ObservableObject {
                     } catch let error {
                         print("Error processing audio buffer: \(error)")
                     }
-                })
+                }
+            )
 
             do {
                 try engine.start()
@@ -121,7 +127,8 @@ public class SoundDetection: ObservableObject {
      - volumeThreshold: The threshold value in decibels (dB) above which a sound is considered detected.
      */
     private func processAudioBufferForSoundDetection(
-        from buffer: AVAudioPCMBuffer, _ volumeThreshold: Int = 60
+        from buffer: AVAudioPCMBuffer,
+        _ volumeThreshold: Int = 60
     ) throws {
         let amplitude = try getMaxAmplitude(from: buffer)
         let soundVolume = calculateValue(from: amplitude)
@@ -166,9 +173,11 @@ public class SoundDetection: ObservableObject {
         let sourceFormat = buffer.format
         guard
             let targetFormat = AVAudioFormat(
-                commonFormat: .pcmFormatInt16, sampleRate: sourceFormat.sampleRate,
+                commonFormat: .pcmFormatInt16,
+                sampleRate: sourceFormat.sampleRate,
                 channels: sourceFormat.channelCount,
-                interleaved: true)
+                interleaved: true
+            )
         else {
             throw SoundDetectionError.audioConverterInitializationFailed
         }
@@ -178,7 +187,9 @@ public class SoundDetection: ObservableObject {
         }
 
         let outputBuffer = AVAudioPCMBuffer(
-            pcmFormat: targetFormat, frameCapacity: buffer.frameCapacity)
+            pcmFormat: targetFormat,
+            frameCapacity: buffer.frameCapacity
+        )
         let inputBlock: AVAudioConverterInputBlock = { inNumPackets, outStatus in
             outStatus.pointee = .haveData
             return buffer

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalAppScreenShareTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalAppScreenShareTrack.swift
@@ -5,15 +5,24 @@ public class LocalAppScreenShareTrack: LocalVideoTrack, LocalTrack {
     internal var capturer: AppScreenShareCapturer
 
     internal init(
-        mediaTrack: RTCVideoTrack, videoSource: RTCVideoSource, endpointId: String, metadata: Metadata = Metadata(),
-        videoParameters: VideoParameters, capturer: AppScreenShareCapturer
+        mediaTrack: RTCVideoTrack,
+        videoSource: RTCVideoSource,
+        endpointId: String,
+        metadata: Metadata = Metadata(),
+        videoParameters: VideoParameters,
+        capturer: AppScreenShareCapturer
 
     ) {
         mediaTrack.shouldReceive = false
         self.capturer = capturer
         super.init(
-            mediaTrack: mediaTrack, videoSource: videoSource, endpointId: endpointId, rtcEngineId: nil,
-            videoParameters: videoParameters, metadata: metadata)
+            mediaTrack: mediaTrack,
+            videoSource: videoSource,
+            endpointId: endpointId,
+            rtcEngineId: nil,
+            videoParameters: videoParameters,
+            metadata: metadata
+        )
     }
 
     public func start() {

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalAudioTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalAudioTrack.swift
@@ -6,7 +6,10 @@ public class LocalAudioTrack: Track, LocalTrack {
     internal var audioSource: RTCAudioSource
 
     internal init(
-        mediaTrack: RTCAudioTrack, audioSource: RTCAudioSource, endpointId: String, metadata: Metadata = Metadata()
+        mediaTrack: RTCAudioTrack,
+        audioSource: RTCAudioSource,
+        endpointId: String,
+        metadata: Metadata = Metadata()
     ) {
         config = AudioUtils.createAudioConfig()
         self.audioSource = audioSource
@@ -17,8 +20,11 @@ public class LocalAudioTrack: Track, LocalTrack {
         self.config = oldTrack.config
         self.audioSource = oldTrack.audioSource
         super.init(
-            mediaTrack: mediaTrack, endpointId: oldTrack.endpointId, rtcEngineId: oldTrack.rtcEngineId,
-            metadata: oldTrack.metadata)
+            mediaTrack: mediaTrack,
+            endpointId: oldTrack.endpointId,
+            rtcEngineId: oldTrack.rtcEngineId,
+            metadata: oldTrack.metadata
+        )
     }
 
     internal var audioTrack: RTCAudioTrack {

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalBroadcastScreenShareTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalBroadcastScreenShareTrack.swift
@@ -5,14 +5,22 @@ public class LocalBroadcastScreenShareTrack: LocalVideoTrack, LocalTrack {
     private let appGroup: String
 
     internal init(
-        mediaTrack: RTCVideoTrack, videoSource: RTCVideoSource, endpointId: String, metadata: Metadata = Metadata(),
+        mediaTrack: RTCVideoTrack,
+        videoSource: RTCVideoSource,
+        endpointId: String,
+        metadata: Metadata = Metadata(),
         appGroup: String,
         videoParameters: VideoParameters
     ) {
         self.appGroup = appGroup
         super.init(
-            mediaTrack: mediaTrack, videoSource: videoSource, endpointId: endpointId, rtcEngineId: nil,
-            videoParameters: videoParameters, metadata: metadata)
+            mediaTrack: mediaTrack,
+            videoSource: videoSource,
+            endpointId: endpointId,
+            rtcEngineId: nil,
+            videoParameters: videoParameters,
+            metadata: metadata
+        )
     }
 
     func start() {}

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalCameraTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalCameraTrack.swift
@@ -18,15 +18,24 @@ public class LocalCameraTrack: LocalVideoTrack, LocalTrack {
     }
 
     internal init(
-        mediaTrack: RTCVideoTrack, videoSource: RTCVideoSource, endpointId: String, metadata: Metadata = Metadata(),
-        videoParameters: VideoParameters, capturer: CameraCapturer
+        mediaTrack: RTCVideoTrack,
+        videoSource: RTCVideoSource,
+        endpointId: String,
+        metadata: Metadata = Metadata(),
+        videoParameters: VideoParameters,
+        capturer: CameraCapturer
 
     ) {
         mediaTrack.shouldReceive = false
         self.capturer = capturer
         super.init(
-            mediaTrack: mediaTrack, videoSource: videoSource, endpointId: endpointId, rtcEngineId: nil,
-            videoParameters: videoParameters, metadata: metadata)
+            mediaTrack: mediaTrack,
+            videoSource: videoSource,
+            endpointId: endpointId,
+            rtcEngineId: nil,
+            videoParameters: videoParameters,
+            metadata: metadata
+        )
     }
 
     override func replace(mediaTrack: RTCVideoTrack) {

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalCustomVideoTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/LocalCustomVideoTrack.swift
@@ -2,11 +2,19 @@ import WebRTC
 
 public class LocalCustomVideoTrack: LocalVideoTrack {
     internal init(
-        mediaTrack: RTCVideoTrack, videoSource: RTCVideoSource, endpointId: String, metadata: Metadata = Metadata(),
+        mediaTrack: RTCVideoTrack,
+        videoSource: RTCVideoSource,
+        endpointId: String,
+        metadata: Metadata = Metadata(),
         videoParameters: VideoParameters
     ) {
         super.init(
-            mediaTrack: mediaTrack, videoSource: videoSource, endpointId: endpointId, rtcEngineId: nil,
-            videoParameters: videoParameters, metadata: metadata)
+            mediaTrack: mediaTrack,
+            videoSource: videoSource,
+            endpointId: endpointId,
+            rtcEngineId: nil,
+            videoParameters: videoParameters,
+            metadata: metadata
+        )
     }
 }

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/RemoteAudioTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/RemoteAudioTrack.swift
@@ -5,7 +5,10 @@ public class RemoteAudioTrack: Track {
     private var vadChangedListener: ((_ track: Track) throws -> Void)?
 
     init(
-        audioTrack: RTCAudioTrack, endpointId: String, rtcEngineId: String? = nil, metadata: Metadata = Metadata(),
+        audioTrack: RTCAudioTrack,
+        endpointId: String,
+        rtcEngineId: String? = nil,
+        metadata: Metadata = Metadata(),
         id: String = UUID().uuidString
     ) {
         super.init(mediaTrack: audioTrack, endpointId: endpointId, rtcEngineId: rtcEngineId, metadata: metadata, id: id)

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/RemoteVideoTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/RemoteVideoTrack.swift
@@ -7,7 +7,10 @@ public class RemoteVideoTrack: VideoTrack {
     private var onTrackEncodingChangedListener: ((_ track: Track) throws -> Void)?
 
     override init(
-        mediaTrack: RTCVideoTrack, endpointId: String, rtcEngineId: String?, metadata: Metadata = Metadata(),
+        mediaTrack: RTCVideoTrack,
+        endpointId: String,
+        rtcEngineId: String?,
+        metadata: Metadata = Metadata(),
         id: String = UUID().uuidString
     ) {
         super.init(mediaTrack: mediaTrack, endpointId: endpointId, rtcEngineId: rtcEngineId, metadata: metadata, id: id)

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/Track.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/Track.swift
@@ -22,7 +22,10 @@ open class Track: Equatable {
     */
 
     init(
-        mediaTrack: RTCMediaStreamTrack?, endpointId: String, rtcEngineId: String?, metadata: Metadata = Metadata(),
+        mediaTrack: RTCMediaStreamTrack?,
+        endpointId: String,
+        rtcEngineId: String?,
+        metadata: Metadata = Metadata(),
         id: String = UUID().uuidString
     ) {
         self.mediaTrack = mediaTrack

--- a/packages/ios-client/Sources/FishjamClient/media/Tracks/VideoTrack.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/Tracks/VideoTrack.swift
@@ -9,8 +9,12 @@ open class LocalVideoTrack: VideoTrack {
     var videoSource: RTCVideoSource
 
     init(
-        mediaTrack: RTCVideoTrack, videoSource: RTCVideoSource, endpointId: String, rtcEngineId: String?,
-        videoParameters: VideoParameters, metadata: Metadata = Metadata(),
+        mediaTrack: RTCVideoTrack,
+        videoSource: RTCVideoSource,
+        endpointId: String,
+        rtcEngineId: String?,
+        videoParameters: VideoParameters,
+        metadata: Metadata = Metadata(),
         id: String = UUID().uuidString
     ) {
         self.videoParameters = videoParameters
@@ -25,7 +29,10 @@ open class LocalVideoTrack: VideoTrack {
 
 open class VideoTrack: Track, RTCVideoViewDelegate {
     init(
-        mediaTrack: RTCVideoTrack, endpointId: String, rtcEngineId: String?, metadata: Metadata = Metadata(),
+        mediaTrack: RTCVideoTrack,
+        endpointId: String,
+        rtcEngineId: String?,
+        metadata: Metadata = Metadata(),
         id: String = UUID().uuidString
     ) {
         super.init(mediaTrack: mediaTrack, endpointId: endpointId, rtcEngineId: rtcEngineId, metadata: metadata, id: id)

--- a/packages/ios-client/Sources/FishjamClient/media/VideoParameters.swift
+++ b/packages/ios-client/Sources/FishjamClient/media/VideoParameters.swift
@@ -111,8 +111,10 @@ public struct VideoParameters {
     public let simulcastConfig: SimulcastConfig
 
     public init(
-        dimensions: Dimensions, maxBandwidth: TrackBandwidthLimit = .BandwidthLimit(0),
-        maxFps: Int = 30, simulcastConfig: SimulcastConfig = SimulcastConfig()
+        dimensions: Dimensions,
+        maxBandwidth: TrackBandwidthLimit = .BandwidthLimit(0),
+        maxFps: Int = 30,
+        simulcastConfig: SimulcastConfig = SimulcastConfig()
     ) {
         self.dimensions = dimensions
         self.maxBandwidth = maxBandwidth

--- a/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/Endpoint.swift
@@ -10,7 +10,9 @@ public struct Endpoint {
     }
 
     public func copyWith(
-        id: String? = nil, metadata: Metadata? = nil, tracks: [String: Track]? = nil
+        id: String? = nil,
+        metadata: Metadata? = nil,
+        tracks: [String: Track]? = nil
     ) -> Self {
         return Endpoint(
             id: id ?? self.id,

--- a/packages/ios-client/Sources/FishjamClient/models/RTCStats.swift
+++ b/packages/ios-client/Sources/FishjamClient/models/RTCStats.swift
@@ -27,8 +27,15 @@ public struct RTCOutboundStats: RTCStats {
     public let qualityLimitationDurations: QualityLimitationDurations?
 
     public init(
-        kind: String = "", rid: String = "", bytesSent: UInt = 0, targetBitrate: Double = 0.0, packetsSent: UInt = 0,
-        framesEncoded: UInt = 0, framesPerSecond: Double = 0.0, frameWidth: UInt = 0, frameHeight: UInt = 0,
+        kind: String = "",
+        rid: String = "",
+        bytesSent: UInt = 0,
+        targetBitrate: Double = 0.0,
+        packetsSent: UInt = 0,
+        framesEncoded: UInt = 0,
+        framesPerSecond: Double = 0.0,
+        frameWidth: UInt = 0,
+        frameHeight: UInt = 0,
         qualityLimitationDurations: QualityLimitationDurations? = nil
     ) {
         self.kind = kind
@@ -57,9 +64,15 @@ public struct RTCInboundStats: RTCStats {
     public let framesDropped: UInt
 
     public init(
-        kind: String = "", jitter: Double = 0.0, packetsLost: UInt = 0, packetsReceived: UInt = 0,
+        kind: String = "",
+        jitter: Double = 0.0,
+        packetsLost: UInt = 0,
+        packetsReceived: UInt = 0,
         bytesReceived: UInt = 0,
-        framesReceived: UInt = 0, frameWidth: UInt = 0, frameHeight: UInt = 0, framesPerSecond: Double = 0.0,
+        framesReceived: UInt = 0,
+        frameWidth: UInt = 0,
+        frameHeight: UInt = 0,
+        framesPerSecond: Double = 0.0,
         framesDropped: UInt = 0
     ) {
         self.kind = kind

--- a/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
+++ b/packages/ios-client/Sources/FishjamClient/ui/VideoView.swift
@@ -174,7 +174,8 @@ public class VideoView: UIView, VideoTrackDelegate {
                 x: -((size.width - viewSize.width) / 2),
                 y: -((size.height - viewSize.height) / 2),
                 width: size.width,
-                height: size.height)
+                height: size.height
+            )
         } else {
             rendererView.frame = bounds
         }

--- a/packages/ios-client/Sources/FishjamClient/utils/AnyJson.swift
+++ b/packages/ios-client/Sources/FishjamClient/utils/AnyJson.swift
@@ -48,7 +48,8 @@ public struct AnyJson: Codable {
     }
 
     static func decode(
-        from container: inout KeyedDecodingContainer<JSONCodingKey>, forKey key: JSONCodingKey
+        from container: inout KeyedDecodingContainer<JSONCodingKey>,
+        forKey key: JSONCodingKey
     ) throws -> Any {
         if let value = try? container.decode(Bool.self, forKey: key) {
             return value
@@ -75,7 +76,9 @@ public struct AnyJson: Codable {
             AnyJson.self,
             .init(
                 codingPath: container.codingPath,
-                debugDescription: "Couldn't parse object to Metadata: unknown type!"))
+                debugDescription: "Couldn't parse object to Metadata: unknown type!"
+            )
+        )
     }
 
     static func decode(from container: inout UnkeyedDecodingContainer) throws -> Any {
@@ -104,7 +107,9 @@ public struct AnyJson: Codable {
             AnyJson.self,
             .init(
                 codingPath: container.codingPath,
-                debugDescription: "Couldn't parse object to Metadata: decoding from container failed"))
+                debugDescription: "Couldn't parse object to Metadata: decoding from container failed"
+            )
+        )
     }
 
     // MARK: Encoding
@@ -115,7 +120,8 @@ public struct AnyJson: Codable {
     }
 
     static func encode(
-        to container: inout KeyedEncodingContainer<JSONCodingKey>, dictionary: [String: Any]
+        to container: inout KeyedEncodingContainer<JSONCodingKey>,
+        dictionary: [String: Any]
     ) throws {
         for (key, value) in dictionary {
             let key = JSONCodingKey(stringValue: key)!
@@ -152,7 +158,8 @@ public struct AnyJson: Codable {
                             codingPath: container.codingPath,
                             debugDescription:
                                 "Couldn't parse object to Metadata: unexpected type to encode: \(String(describing: value))"
-                        ))
+                        )
+                    )
                 }
             }
         }
@@ -190,7 +197,8 @@ public struct AnyJson: Codable {
                             codingPath: container.codingPath,
                             debugDescription:
                                 "Couldn't parse object to Metadata: unexpected type to encode: \(String(describing: value))"
-                        ))
+                        )
+                    )
                 }
             }
         }
@@ -221,7 +229,8 @@ public struct AnyJson: Codable {
                         codingPath: container.codingPath,
                         debugDescription:
                             "Couldn't parse object to Metadata: unexpected type to encode: \(String(describing: value))"
-                    ))
+                    )
+                )
             }
         }
     }

--- a/packages/ios-client/Sources/FishjamClient/utils/AudioUtils.swift
+++ b/packages/ios-client/Sources/FishjamClient/utils/AudioUtils.swift
@@ -10,7 +10,9 @@ internal class AudioUtils {
     ]
 
     static let audioConstraints = RTCMediaConstraints(
-        mandatoryConstraints: nil, optionalConstraints: constraints)
+        mandatoryConstraints: nil,
+        optionalConstraints: constraints
+    )
 
     static func createAudioConfig() -> RTCAudioSessionConfiguration {
         let config = RTCAudioSessionConfiguration.webRTC()

--- a/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionFactoryWrapper.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionFactoryWrapper.swift
@@ -11,10 +11,14 @@ internal class PeerConnectionFactoryWrapper {
         let encoderFactory = getEncoderFactory(from: encoder)
 
         let simulcastFactory = RTCVideoEncoderFactorySimulcast(
-            primary: encoderFactory, fallback: RTCDefaultVideoEncoderFactory())
+            primary: encoderFactory,
+            fallback: RTCDefaultVideoEncoderFactory()
+        )
 
         self.factory = RTCPeerConnectionFactory(
-            encoderFactory: simulcastFactory, decoderFactory: decoderFactory)
+            encoderFactory: simulcastFactory,
+            decoderFactory: decoderFactory
+        )
 
     }
 

--- a/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionManager.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/PeerConnectionManager.swift
@@ -24,7 +24,9 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
     private var midToTrackId: [String: String] = [:]
 
     private static let mediaConstraints = RTCMediaConstraints(
-        mandatoryConstraints: nil, optionalConstraints: ["DtlsSrtpKeyAgreement": kRTCMediaConstraintsValueTrue])
+        mandatoryConstraints: nil,
+        optionalConstraints: ["DtlsSrtpKeyAgreement": kRTCMediaConstraintsValueTrue]
+    )
     private var streamIds: [String] = [UUID().uuidString]
 
     internal init(config: RTCConfiguration, peerConnectionFactory: PeerConnectionFactoryWrapper) {
@@ -143,7 +145,9 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
 
         guard
             let peerConnection = peerConnectionFactory.createPeerConnection(
-                config, constraints: Self.mediaConstraints)
+                config,
+                constraints: Self.mediaConstraints
+            )
         else {
             fatalError("Failed to initialize new PeerConnection")
         }
@@ -298,12 +302,15 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
                                 offer.sdp,
                                 self.getMidToTrackId(localTracks: localTracks),
                                 TrackBitratesMapper.mapTracksToProtoBitrates(localTracks: localTracks),
-                                nil)
+                                nil
+                            )
                             return
                         }
                         onCompletion(nil, nil, nil, err)
-                    })
-            })
+                    }
+                )
+            }
+        )
     }
 
     func disableEncodings(sdpAnswer: String, encodingsToDisable: [String]) -> String {
@@ -359,7 +366,8 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
                     return
                 }
                 sdkLogger.error("error occured while trying to set a remote description \(err)")
-            })
+            }
+        )
     }
 
     public func onRemoteCandidate(candidate: RTCIceCandidate) {
@@ -375,7 +383,8 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
                 }
 
                 sdkLogger.error("error occured  during remote ice candidate processing: \(err)")
-            })
+            }
+        )
     }
 
     public func peerConnection(_: RTCPeerConnection, didAdd _: RTCMediaStream) {
@@ -397,11 +406,13 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
         ]
 
         sdkLogger.debug(
-            "\(pcLogPrefix) changed signaling state to \(descriptions[stateChanged] ?? "unknown")")
+            "\(pcLogPrefix) changed signaling state to \(descriptions[stateChanged] ?? "unknown")"
+        )
     }
 
     public func peerConnection(
-        _: RTCPeerConnection, didStartReceivingOn transceiver: RTCRtpTransceiver
+        _: RTCPeerConnection,
+        didStartReceivingOn transceiver: RTCRtpTransceiver
     ) {
         guard
             let trackId = midToTrackId[transceiver.mid]
@@ -423,7 +434,8 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
 
     public func peerConnection(
         _: RTCPeerConnection,
-        didAdd receiver: RTCRtpReceiver, streams _: [RTCMediaStream]
+        didAdd receiver: RTCRtpReceiver,
+        streams _: [RTCMediaStream]
     ) {
         sdkLogger.info("\(pcLogPrefix) new receiver has been added: \(receiver.receiverId)")
     }
@@ -433,8 +445,11 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
     }
 
     public func peerConnection(
-        _: RTCPeerConnection, didChangeLocalCandidate local: RTCIceCandidate,
-        remoteCandidate remote: RTCIceCandidate, lastReceivedMs _: Int32, changeReason reason: String
+        _: RTCPeerConnection,
+        didChangeLocalCandidate local: RTCIceCandidate,
+        remoteCandidate remote: RTCIceCandidate,
+        lastReceivedMs _: Int32,
+        changeReason reason: String
     ) {
         sdkLogger.debug(
             "\(pcLogPrefix) a local candidate has been changed due to: '\(reason)'\nlocal: \(local.sdp)\nremote: \(remote.sdp)"
@@ -469,7 +484,8 @@ internal class PeerConnectionManager: NSObject, RTCPeerConnectionDelegate {
         ]
 
         sdkLogger.debug(
-            "\(pcLogPrefix) new ice gathering state: \(descriptions[newState] ?? "unknown")")
+            "\(pcLogPrefix) new ice gathering state: \(descriptions[newState] ?? "unknown")"
+        )
     }
 
     public func peerConnection(_: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {

--- a/packages/ios-client/Sources/FishjamClient/webrtc/RTCEngineCommunication.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/RTCEngineCommunication.swift
@@ -58,7 +58,9 @@ internal class RTCEngineCommunication {
     }
 
     func sdpOffer(
-        sdp: String, trackIdToTrackMetadata: [String: Metadata], midToTrackId: [String: String],
+        sdp: String,
+        trackIdToTrackMetadata: [String: Metadata],
+        midToTrackId: [String: String],
         trackIdToBitrates: [String: Fishjam_MediaEvents_Peer_MediaEvent.TrackBitrates]
     ) {
         var sdpOffer = Fishjam_MediaEvents_Peer_MediaEvent.SdpOffer()
@@ -93,7 +95,8 @@ internal class RTCEngineCommunication {
             for listener in listeners {
                 listener.onEndpointAdded(
                     endpointId: endpointAdded.endpointID,
-                    metadata: (try? AnyJson(from: endpointAdded.metadataJson)) ?? Metadata())
+                    metadata: (try? AnyJson(from: endpointAdded.metadataJson)) ?? Metadata()
+                )
             }
         case .endpointRemoved(let endpointRemoved):
             for listener in listeners {

--- a/packages/ios-client/Sources/FishjamClient/webrtc/RTCEngineListener.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/RTCEngineListener.swift
@@ -1,8 +1,10 @@
 internal protocol RTCEngineListener: AnyObject {
     func onSendMediaEvent(event: Fishjam_MediaEvents_Peer_MediaEvent.OneOf_Content)
     func onConnected(
-        endpointId: String, endpointIdToEndpoint: [String: Fishjam_MediaEvents_Server_MediaEvent.Endpoint],
-        iceServers: [Fishjam_MediaEvents_Server_MediaEvent.IceServer])
+        endpointId: String,
+        endpointIdToEndpoint: [String: Fishjam_MediaEvents_Server_MediaEvent.Endpoint],
+        iceServers: [Fishjam_MediaEvents_Server_MediaEvent.IceServer]
+    )
     func onEndpointAdded(endpointId: String, metadata: Metadata?)
     func onEndpointRemoved(endpointId: String)
     func onEndpointUpdated(endpointId: String, metadata: Metadata?)

--- a/packages/ios-client/Sources/FishjamClient/webrtc/StatsCollector.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/StatsCollector.swift
@@ -23,7 +23,8 @@ class StatsCollector {
             bandwidth: duration?["bandwidth"] ?? 0.0,
             cpu: duration?["cpu"] ?? 0.0,
             none: duration?["none"] ?? 0.0,
-            other: duration?["other"] ?? 0.0)
+            other: duration?["other"] ?? 0.0
+        )
 
         return RTCOutboundStats(
             kind: stats.values["kind"] as? String ?? "",

--- a/packages/ios-client/Sources/FishjamClient/webrtc/helpers/TrackBitratesMapper.swift
+++ b/packages/ios-client/Sources/FishjamClient/webrtc/helpers/TrackBitratesMapper.swift
@@ -23,6 +23,7 @@ struct TrackBitratesMapper {
                 trackBitrates.variantBitrates = bitrates
 
                 return (track.webrtcId, trackBitrates)
-            })
+            }
+        )
     }
 }

--- a/packages/ios-client/swift-format-config.json
+++ b/packages/ios-client/swift-format-config.json
@@ -9,7 +9,7 @@
   "indentSwitchCaseLabels": false,
   "lineBreakAroundMultilineExpressionChainComponents": false,
   "lineBreakBeforeControlFlowKeywords": false,
-  "lineBreakBeforeEachArgument": false,
+  "lineBreakBeforeEachArgument": true,
   "lineBreakBeforeEachGenericRequirement": false,
   "lineLength": 120,
   "maximumBlankLines": 1,


### PR DESCRIPTION
## Description

- Enabled lineBreakBeforeEachArgument rule

## Motivation and Context

We want this rule enforced.

## How has this been tested?

- none

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.