### PR TITLE
FCE-1411: Fix aspect ratio on Android Example

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
@@ -83,12 +83,18 @@ class VideoScalingCalculator {
     viewWidth: Float,
     viewHeight: Float,
     frameAspectRatio: Float
-  ): Pair<Float, Float> =
-    if (frameAspectRatio > viewWidth / viewHeight) {
-      Pair(viewWidth, viewWidth / frameAspectRatio)
+  ): Pair<Float, Float> {
+
+    // These are floats so we need to round them up to compare
+    val viewAspectRatio = (viewWidth / viewHeight).roundTo2DecimalPlaces()
+    val roundedFrameAspectRatio = frameAspectRatio.roundTo2DecimalPlaces()
+
+    return if (roundedFrameAspectRatio > viewAspectRatio) {
+      Pair(viewWidth, (viewWidth / roundedFrameAspectRatio))
     } else {
-      Pair(viewHeight * frameAspectRatio, viewHeight)
+      Pair((viewHeight * roundedFrameAspectRatio), viewHeight)
     }
+  }
 
   private fun calculateTransformMatrix(
     scaledWidth: Int,
@@ -96,10 +102,9 @@ class VideoScalingCalculator {
     viewWidth: Int,
     viewHeight: Int
   ): Matrix {
-    // Center the view along the x axis.
-    val xOffset = (viewWidth / 2) - (scaledWidth / 2)
-    // We always fill the full height, so start at 0
-    val yOffset = 0
+    // Center along whichever axis has leftover space
+    val xOffset = if (scaledWidth < viewWidth) (viewWidth / 2) - (scaledWidth / 2) else 0
+    val yOffset = if (scaledHeight < viewHeight) (viewHeight / 2) - (scaledHeight / 2) else 0
 
     return Matrix().apply {
       postScale(
@@ -112,5 +117,9 @@ class VideoScalingCalculator {
         yOffset.toFloat()
       )
     }
+  }
+
+  private fun Float.roundTo2DecimalPlaces(): Float {
+    return (this * 100).toInt() / 100f
   }
 }

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
@@ -84,7 +84,6 @@ class VideoScalingCalculator {
     viewHeight: Float,
     frameAspectRatio: Float
   ): Pair<Float, Float> {
-
     // These are floats so we need to round them up to compare
     val viewAspectRatio = (viewWidth / viewHeight).roundTo2DecimalPlaces()
     val roundedFrameAspectRatio = frameAspectRatio.roundTo2DecimalPlaces()
@@ -119,7 +118,5 @@ class VideoScalingCalculator {
     }
   }
 
-  private fun Float.roundTo2DecimalPlaces(): Float {
-    return (this * 100).toInt() / 100f
-  }
+  private fun Float.roundTo2DecimalPlaces(): Float = (this * 100).toInt() / 100f
 }

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
@@ -85,10 +85,10 @@ class VideoScalingCalculator {
     frameAspectRatio: Float
   ): Pair<Float, Float> {
     // These are floats so we need to round them up to compare
-    val viewAspectRatio = (viewWidth / viewHeight).roundTo2DecimalPlaces()
+    val roundedViewAspectRatio = (viewWidth / viewHeight).roundTo2DecimalPlaces()
     val roundedFrameAspectRatio = frameAspectRatio.roundTo2DecimalPlaces()
 
-    return if (roundedFrameAspectRatio > viewAspectRatio) {
+    return if (roundedFrameAspectRatio > roundedViewAspectRatio) {
       Pair(viewWidth, (viewWidth / roundedFrameAspectRatio))
     } else {
       Pair((viewHeight * roundedFrameAspectRatio), viewHeight)

--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/ui/VideoScalingCalculator.kt
@@ -102,8 +102,8 @@ class VideoScalingCalculator {
     viewHeight: Int
   ): Matrix {
     // Center along whichever axis has leftover space
-    val xOffset = if (scaledWidth < viewWidth) (viewWidth / 2) - (scaledWidth / 2) else 0
-    val yOffset = if (scaledHeight < viewHeight) (viewHeight / 2) - (scaledHeight / 2) else 0
+    val xOffset = maxOf(viewWidth - scaledWidth, 0) / 2
+    val yOffset = maxOf(viewHeight - scaledHeight, 0) / 2
 
     return Matrix().apply {
       postScale(


### PR DESCRIPTION
## Description

- Fix aspect ratio calculations. The issue was caused by floats comparison.

## Motivation and Context

- When using a custom aspect ratio the view was incorrectly calculated if aspect ratios where the same.

## How has this been tested?

- Tested on Android

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
