### PR TITLE
FCE-1181: Remove native VideoPreviewView

### DIFF
--- a/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
+++ b/examples/fishjam-chat/screens/PreviewScreen/PreviewScreen.tsx
@@ -104,7 +104,10 @@ function PreviewScreen({
     <SafeAreaView style={styles.container}>
       <View style={styles.cameraPreview}>
         {!isIosSimulator && isCameraOn ? (
-          <VideoPreviewView style={styles.cameraPreviewView} />
+          <VideoPreviewView
+            style={styles.cameraPreviewView}
+            videoLayout="FIT"
+          />
         ) : (
           <NoCameraView username={route?.params?.userName || 'RN Mobile'} />
         )}
@@ -122,7 +125,6 @@ function PreviewScreen({
         <SwitchCameraButton switchCamera={toggleSwitchCamera} />
         <SwitchOutputDeviceButton bottomSheetRef={bottomSheetRef} />
       </View>
-
       <View style={styles.joinButton}>
         <Button
           title="Join Room"
@@ -162,7 +164,6 @@ const styles = StyleSheet.create({
   cameraPreview: {
     flex: 6,
     margin: 24,
-    // TODO: This should no longer be needed after FCE-1181
     aspectRatio: 9 / 16,
     alignItems: 'center',
     borderRadius: 12,

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
@@ -2,7 +2,6 @@ package io.fishjam.reactnative
 
 import android.content.Context
 import com.fishjamcloud.client.media.LocalVideoTrack
-import com.fishjamcloud.client.media.VideoTrack
 import expo.modules.kotlin.AppContext
 import io.fishjam.reactnative.managers.LocalCameraTrackChangedListener
 
@@ -11,14 +10,15 @@ class VideoPreviewView(
   appContext: AppContext
 ) : VideoRendererView(context, appContext),
   LocalCameraTrackChangedListener {
-    private fun trySetLocalCameraTrack() {
-
-      (RNFishjamClient.fishjamClient.getLocalEndpoint().tracks.values.firstOrNull { track ->
-          track is LocalVideoTrack
-        } as? LocalVideoTrack?)?.let {
-        init(it.id())
-      }
+  private fun trySetLocalCameraTrack() {
+    (
+      RNFishjamClient.fishjamClient.getLocalEndpoint().tracks.values.firstOrNull { track ->
+        track is LocalVideoTrack
+      } as? LocalVideoTrack?
+    )?.let {
+      init(it.id())
     }
+  }
 
   override fun onDetachedFromWindow() {
     RNFishjamClient.localCameraTracksChangedListenersManager.remove(this)

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoPreviewView.kt
@@ -9,38 +9,30 @@ import io.fishjam.reactnative.managers.LocalCameraTrackChangedListener
 class VideoPreviewView(
   context: Context,
   appContext: AppContext
-) : VideoView(context, appContext),
+) : VideoRendererView(context, appContext),
   LocalCameraTrackChangedListener {
-  private var localVideoTrack: LocalVideoTrack? = null
+    private fun trySetLocalCameraTrack() {
 
-  private fun trySetLocalCameraTrack() {
-    localVideoTrack =
-      RNFishjamClient.fishjamClient.getLocalEndpoint().tracks.values.firstOrNull { track ->
-        track is LocalVideoTrack
-      } as? LocalVideoTrack?
-    videoView.let { localVideoTrack?.addRenderer(it) }
-  }
-
-  private fun initialize() {
-    trySetLocalCameraTrack()
-    super.setupTrack()
-  }
+      (RNFishjamClient.fishjamClient.getLocalEndpoint().tracks.values.firstOrNull { track ->
+          track is LocalVideoTrack
+        } as? LocalVideoTrack?)?.let {
+        init(it.id())
+      }
+    }
 
   override fun onDetachedFromWindow() {
     RNFishjamClient.localCameraTracksChangedListenersManager.remove(this)
-    videoView.let { localVideoTrack?.removeRenderer(it) }
     super.onDetachedFromWindow()
   }
 
   override fun onAttachedToWindow() {
     RNFishjamClient.localCameraTracksChangedListenersManager.add(this)
+    activeVideoTrack?.removeRenderer(videoView)
     super.onAttachedToWindow()
-    initialize()
+    trySetLocalCameraTrack()
   }
 
-  override fun getVideoTrack(): VideoTrack? = localVideoTrack
-
   override fun onLocalCameraTrackChanged() {
-    if (localVideoTrack == null) trySetLocalCameraTrack()
+    if (activeVideoTrack == null) trySetLocalCameraTrack()
   }
 }

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoRendererView.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/VideoRendererView.kt
@@ -10,13 +10,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class VideoRendererView(
+open class VideoRendererView(
   context: Context,
   appContext: AppContext
 ) : VideoView(context, appContext),
   TrackUpdateListener,
   VideoTrackListener {
-  private var activeVideoTrack: VideoTrack? = null
+  protected var activeVideoTrack: VideoTrack? = null
   private var trackId: String? = null
 
   init {


### PR DESCRIPTION
## Description

I could not completely remove it due to the need for a native callback when the view is hidden; however, I did a refactor that makes Preview inherit from `VideoRendererView`. That solves the issue of duplicated code (aka hidden errors). 

## Motivation and Context

- More code sharing, and easier maintenance. 

## How has this been tested?

- Run and tested Android + iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
