### PR TITLE
FCE-1420: Audio only randomly crashing on android

### DIFF
--- a/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
+++ b/packages/android-client/FishjamClient/src/main/java/com/fishjamcloud/client/FishjamClientInternal.kt
@@ -266,6 +266,10 @@ internal class FishjamClientInternal(
     commandsQueue.finishCommand()
     reconnectionManager.onReconnected()
 
+    if (localEndpoint.tracks.isEmpty()) {
+      return
+    }
+
     coroutineScope.launch {
       commandsQueue.addCommand(
         Command(CommandName.ADD_TRACK) {


### PR DESCRIPTION
## Description

- If there are no tracks, don't renegotiate / add track. 

## Motivation and Context

- When joining a room with no tracks, fishjam was closing the connection. The flow was like that CONNECTED => RENEGOTIATE TRACKS => SDP OFFER. We cannot send sdp offer unless we have tracks to share. This was already properly handled on iOS.

## How has this been tested?

- Tested no tracks room on Android/iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
