### PR TITLE
Revert "Bump react-native-toast-message from 2.2.1 to 2.3.3"

### DIFF
--- a/internal/fishjam-chat/package.json
+++ b/internal/fishjam-chat/package.json
@@ -30,7 +30,7 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
-    "react-native-toast-message": "^2.3.3",
+    "react-native-toast-message": "^2.2.1",
     "react-native-url-polyfill": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,7 +3119,7 @@ __metadata:
     react-native-reanimated: "npm:~3.17.4"
     react-native-safe-area-context: "npm:5.4.0"
     react-native-screens: "npm:~4.10.0"
-    react-native-toast-message: "npm:^2.3.3"
+    react-native-toast-message: "npm:^2.2.1"
     react-native-url-polyfill: "npm:^2.0.0"
     typescript: "npm:~5.8.3"
   languageName: unknown
@@ -16056,13 +16056,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-toast-message@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "react-native-toast-message@npm:2.3.3"
+"react-native-toast-message@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "react-native-toast-message@npm:2.2.1"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/10c7cad8ce287786c555c032f03040ecbaeaa920f44b08161364408ccd18bd0fc3a3e6622f80724ad2c0c7366f667e0d946317045aec08d934ca73358811f782
+  checksum: 10c0/03418b03ae345f5fe1c1747a98ae9c420a9ea37402d849920a14bfc6eb01541ad934266ae2656433604448d2fba1266ab6f6be649a49c9b22445e86444c1f6de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts fishjam-cloud/mobile-client-sdk#435