### PR TITLE
FCE-1867: Livestreaming improvements

### DIFF
--- a/internal/fishjam-chat/screens/LivestreamScreen/LivestreamStreamerScreen.tsx
+++ b/internal/fishjam-chat/screens/LivestreamScreen/LivestreamStreamerScreen.tsx
@@ -47,10 +47,8 @@ export default function LivestreamStreamerScreen({ route }: Props) {
     fishjamId,
   });
 
-  const { connect, disconnect, isConnected } = useLivestreamStreamer({
-    camera: cameras[0],
-    preferredVideoCodecs: videoCodecs,
-  });
+  const { connect, disconnect, isConnected, whipClientRef } =
+    useLivestreamStreamer();
 
   const handleConnect = useCallback(async () => {
     try {
@@ -77,7 +75,14 @@ export default function LivestreamStreamerScreen({ route }: Props) {
     <SafeAreaView style={styles.container}>
       <View style={styles.box}>
         <View style={styles.videoView}>
-          <LivestreamStreamer style={styles.whepView} />
+          <LivestreamStreamer
+            style={styles.whepView}
+            camera={cameras[0]}
+            whipClientRef={whipClientRef}
+            preferredVideoCodecs={videoCodecs}
+            videoEnabled={true}
+            audioEnabled={true}
+          />
           <Button
             title={isConnected ? 'Disconnect' : 'Connect'}
             onPress={isConnected ? handleDisconnect : handleConnect}

--- a/packages/react-native-client/src/components/LivestreamStreamer.tsx
+++ b/packages/react-native-client/src/components/LivestreamStreamer.tsx
@@ -1,6 +1,13 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, useEffect, useRef } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
-import { WhipClientView } from 'react-native-whip-whep';
+import {
+  Camera,
+  SenderAudioCodecName,
+  SenderVideoCodecName,
+  VideoParameters,
+  WhipClient,
+  WhipClientView,
+} from 'react-native-whip-whep';
 
 /**
  * Props of the LivestreamView component
@@ -10,6 +17,38 @@ export type LivestreamStreamerProps = {
    * Styles of the LivestreamView component
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Set the video enabled flag.
+   */
+  videoEnabled?: boolean;
+  /**
+   * Set the audio enabled flag.
+   */
+  audioEnabled?: boolean;
+  /**
+   * Set the camera to use for the livestream.
+   * Use {@link cameras} to get the list of supported cameras.
+   */
+  camera: Camera;
+  /**
+   *  Set video parameters for the camera
+   */
+  videoParameters?: VideoParameters;
+  /**
+   * Set the preferred video codecs for sending the video.
+   * Use {@link WhipClient.getSupportedVideoCodecs} to get the list of supported video codecs.
+   */
+  preferredVideoCodecs?: SenderVideoCodecName[];
+  /**
+   * Set the preferred audio codecs for sending the audio.
+   * Use {@link WhipClient.getSupportedAudioCodecs} to get the list of supported audio codecs.
+   */
+  preferredAudioCodecs?: SenderAudioCodecName[];
+
+  /**
+   * Reference to the WhipClient instance. Needs to be passed from the {@link useLivestreamStreamer} hook.
+   */
+  whipClientRef: React.RefObject<WhipClient | null>;
 };
 
 /**
@@ -19,6 +58,45 @@ export type LivestreamStreamerProps = {
  * @param {object} props
  * @param {object} props.style
  */
-export const LivestreamStreamer = ({ style }: LivestreamStreamerProps) => (
-  <WhipClientView style={style as CSSProperties} />
-);
+export const LivestreamStreamer = ({
+  style,
+  whipClientRef,
+  videoEnabled,
+  audioEnabled,
+  camera,
+  videoParameters,
+  preferredVideoCodecs,
+  preferredAudioCodecs,
+}: LivestreamStreamerProps) => {
+  const whipClient = useRef<WhipClient | null>(null);
+
+  useEffect(() => {
+    whipClient.current = new WhipClient(
+      {
+        audioEnabled,
+        videoEnabled,
+        videoParameters,
+        videoDeviceId: camera.id,
+      },
+      preferredVideoCodecs,
+      preferredAudioCodecs,
+    );
+    whipClientRef.current = whipClient.current;
+
+    return () => {
+      whipClient.current?.disconnect();
+      whipClient.current?.cleanup();
+      whipClientRef.current = null;
+    };
+  }, [
+    camera,
+    videoParameters,
+    videoEnabled,
+    audioEnabled,
+    preferredVideoCodecs,
+    preferredAudioCodecs,
+    whipClientRef,
+  ]);
+
+  return <WhipClientView style={style as CSSProperties} />;
+};

--- a/packages/react-native-client/src/components/LivestreamStreamer.tsx
+++ b/packages/react-native-client/src/components/LivestreamStreamer.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, useEffect, useRef } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
 import {
   Camera,
+  cameras,
   SenderAudioCodecName,
   SenderVideoCodecName,
   VideoParameters,
@@ -18,18 +19,18 @@ export type LivestreamStreamerProps = {
    */
   style?: StyleProp<ViewStyle>;
   /**
-   * Set the video enabled flag.
+   * If video track should be enabled.
    */
-  videoEnabled?: boolean;
+  videoEnabled: boolean;
   /**
-   * Set the audio enabled flag.
+   * If audio track should be enabled.
    */
-  audioEnabled?: boolean;
+  audioEnabled: boolean;
   /**
-   * Set the camera to use for the livestream.
+   * Camera to use for the livestream.
    * Use {@link cameras} to get the list of supported cameras.
    */
-  camera: Camera;
+  camera?: Camera;
   /**
    *  Set video parameters for the camera
    */
@@ -76,7 +77,7 @@ export const LivestreamStreamer = ({
         audioEnabled,
         videoEnabled,
         videoParameters,
-        videoDeviceId: camera.id,
+        videoDeviceId: camera?.id ?? cameras[0].id,
       },
       preferredVideoCodecs,
       preferredAudioCodecs,

--- a/packages/react-native-client/src/index.tsx
+++ b/packages/react-native-client/src/index.tsx
@@ -85,7 +85,6 @@ export type { useLivestreamStreamerResult } from './hooks/useLivestreamStreamer'
 export type { UseSandboxProps } from './hooks/useSandbox';
 export type { LivestreamStreamerProps } from './components/LivestreamStreamer';
 export type { ConnectViewerConfig } from './hooks/useLivestreamViewer';
-export type { UseLivestreamStreamerParams as useLivestreamStreamerParams } from './hooks/useLivestreamStreamer';
 // #endregion
 
 // #region hooks


### PR DESCRIPTION
## Description

- Changed API a bit to make it bound to the LivestreamView. Right now it's obvious that you need to use `useLivestreamStreamer` hook (because of the passed reference). It also helps with initializing the view, it's closer to the native cycle rather than the hook.

## Motivation and Context

The current API was not ideal. 

## How has this been tested?

Android + iOS 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
