### PR TITLE
FCE-1882: Fix multiple calls to joinRoom

### DIFF
--- a/.github/workflows/expo_doctor.yaml
+++ b/.github/workflows/expo_doctor.yaml
@@ -20,9 +20,6 @@ jobs:
       - name: 📦 Install dependencies
         run: yarn && yarn build
 
-      - name: List files
-        run: ls -la
-
       - name: 🩺 Run Expo Doctor
-        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest --verbose
+        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest
         working-directory: internal/fishjam-chat

--- a/.github/workflows/expo_doctor.yaml
+++ b/.github/workflows/expo_doctor.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: 📦 Install dependencies
         run: yarn && yarn build
 
+      - name: List files
+        run: ls -la
+
       - name: 🩺 Run Expo Doctor
-        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest
+        run: EXPO_DOCTOR_SKIP_DEPENDENCY_VERSION_CHECK=1 npx expo-doctor@latest --verbose
         working-directory: internal/fishjam-chat

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -299,7 +299,7 @@ class RNFishjamClient(
     promise: Promise
   ) {
     if (connectPromise != null || peerStatus == PeerStatus.Connected) {
-      emitEvent(EmitableEvent.warning("Room already joined or it's connecting. You must call leaveRoom before calling joinRoom again."))
+      emitEvent(EmitableEvent.warning("Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again."))
       return
     }
 

--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -298,6 +298,11 @@ class RNFishjamClient(
     config: ConnectConfig,
     promise: Promise
   ) {
+    if (connectPromise != null || peerStatus == PeerStatus.Connected) {
+      emitEvent(EmitableEvent.warning("Room already joined or it's connecting. You must call leaveRoom before calling joinRoom again."))
+      return
+    }
+
     peerStatus = PeerStatus.Connecting
     connectPromise = promise
     localUserMetadata = mapOf("server" to emptyMap(), "peer" to peerMetadata)
@@ -316,6 +321,9 @@ class RNFishjamClient(
   }
 
   fun leaveRoom() {
+    connectPromise?.reject(JoinError("leaveRoom called before connected"))
+    connectPromise = null
+
     if (isScreenShareOn) {
       stopScreenShare()
     }

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -225,7 +225,7 @@ class RNFishjamClient: FishjamClientListener {
         promise: Promise
     ) {
       guard connectPromise == nil && peerStatus != .connected else {
-        emit(event: .warning(message: "Room already joined or it's connecting. You must call leaveRoom before calling joinRoom again."))
+        emit(event: .warning(message: "Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again."))
         return
       }
     

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -224,6 +224,11 @@ class RNFishjamClient: FishjamClientListener {
         url: String, peerToken: String, peerMetadata: [String: Any], config: ConnectConfig,
         promise: Promise
     ) {
+      guard connectPromise == nil && peerStatus != .connected else {
+        emit(event: .warning(message: "Room already joined or it's connecting. You must call leaveRoom before calling joinRoom again."))
+        return
+      }
+    
         peerStatus = .connecting
         connectPromise = promise
 
@@ -240,6 +245,8 @@ class RNFishjamClient: FishjamClientListener {
     }
 
     func leaveRoom() {
+        connectPromise?.reject("E_MEMBRANE_CONNECT", "leaveRoom called before connected")
+        connectPromise = nil
         if isScreenShareOn {
             let screenShareExtensionBundleId =
                 Bundle.main.infoDictionary?["ScreenShareExtensionBundleId"] as? String

--- a/packages/react-native-client/package.json
+++ b/packages/react-native-client/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "promise-fs": "^2.1.1",
     "protobufjs": "^7.4.0",
-    "react-native-whip-whep": "0.3.0",
+    "react-native-whip-whep": "0.3.1",
     "zod": "^3.25.71"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,7 +3151,7 @@ __metadata:
     promise-fs: "npm:^2.1.1"
     protobufjs: "npm:^7.4.0"
     react-dom: "npm:19.0.0"
-    react-native-whip-whep: "npm:0.3.0"
+    react-native-whip-whep: "npm:0.3.1"
     ts-proto: "npm:^2.7.5"
     typedoc: "npm:^0.28.7"
     typedoc-plugin-mark-react-functional-components: "npm:^0.2.2"
@@ -16308,16 +16308,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-whip-whep@npm:0.3.0":
-  version: 0.3.0
-  resolution: "react-native-whip-whep@npm:0.3.0"
+"react-native-whip-whep@npm:0.3.1":
+  version: 0.3.1
+  resolution: "react-native-whip-whep@npm:0.3.1"
   dependencies:
     zod: "npm:^3.25.71"
   peerDependencies:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10c0/7231497b249cc30dd9b7084b14ed263e9f4819568067855b7d9ce5fd05d207d4c36c75688a0578143f7f42354eb2c5ef27228c43a32697355666d52f08107553
+  checksum: 10c0/5fc3421204b708f57313ee1f7d88b62ca37a9dbaaf0c9fcdc3adaf6ce7713f1ef69c3edb4e558050585a6d4d1b1c73bf5cf4bb3e6f897b05567c571f8b862ddb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Emit a warning and return when `joinRoom` is called after already connected/connecting.
- Bumped rn-whip-whep (broken release was causing iOS build to fail)

## Motivation and Context

- Calling `joinRoom` multiple times was causing an undefined state, which was difficult to debug. 

## How has this been tested?

iOS + Android

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.