### PR TITLE
FCE-1891: joinRoom early return should resolve the promise

### DIFF
--- a/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
+++ b/packages/react-native-client/android/src/main/java/io/fishjam/reactnative/RNFishjamClient.kt
@@ -299,7 +299,7 @@ class RNFishjamClient(
     promise: Promise
   ) {
     if (connectPromise != null || peerStatus == PeerStatus.Connected) {
-      emitEvent(EmitableEvent.warning("Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again."))
+      promise.reject(JoinError("Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again."))
       return
     }
 

--- a/packages/react-native-client/ios/RNFishjamClient.swift
+++ b/packages/react-native-client/ios/RNFishjamClient.swift
@@ -225,7 +225,7 @@ class RNFishjamClient: FishjamClientListener {
         promise: Promise
     ) {
       guard connectPromise == nil && peerStatus != .connected else {
-        emit(event: .warning(message: "Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again."))
+        promise.reject("E_MEMBRANE_CONNECT", "Room already joined or it's connecting. You must call leaveRoom() before calling joinRoom() again.")
         return
       }
     


### PR DESCRIPTION
## Description

While taking a shower tonight, it struck me that in this PR https://github.com/fishjam-cloud/mobile-client-sdk/pull/474 I actually introduced a bug. The `joinRoom` promise should be rejected, instead of just returning the function. 

## Motivation and Context

There was a bug that might lead to errors (unresolved promise).

## How has this been tested?

android + iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
