### PR TITLE
FCE-1895: Fix Expo 54 iOS build

### DIFF
--- a/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
+++ b/packages/ios-client/Sources/FishjamClient/FishjamClient.swift
@@ -23,13 +23,13 @@ internal protocol FishjamWebsocket {
 }
 
 public class FishjamClientWebSocket: FishjamWebsocket {
-    var socket: WebSocket
+    var socket: Starscream.WebSocket
     var delegate: WebSocketDelegate? {
         set { self.socket.delegate = newValue }
         get { self.socket.delegate }
     }
 
-    public init(socket: WebSocket) {
+    public init(socket: Starscream.WebSocket) {
         self.socket = socket
     }
 

--- a/packages/react-native-client/ios/VideoPreviewView.swift
+++ b/packages/react-native-client/ios/VideoPreviewView.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import FishjamCloudClient
+import os.log
 
 class VideoPreviewView: VideoRendererView, LocalCameraTrackChangedListener {
     private var localVideoTrack: LocalCameraTrack?


### PR DESCRIPTION
## Description

- Added missing os.log import and WebSocket disambiguation.

## Motivation and Context

Build was failing due to changes in Expo 54 and iOS SDK 26 (Introduced Websocket which was shadowing Starscream name). 

## How has this been tested?

- Successfully built iOS

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Screenshots (if appropriate)
